### PR TITLE
Add back SDL_FreeWAV

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -2772,6 +2772,12 @@ SDL_Has3DNow(void)
     return SDL_FALSE;
 }
 
+DECLSPEC void SDLCALL
+SDL_FreeWAV(Uint8 * audio_buf)
+{
+    return SDL_free(audio_buf);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -2775,7 +2775,7 @@ SDL_Has3DNow(void)
 DECLSPEC void SDLCALL
 SDL_FreeWAV(Uint8 * audio_buf)
 {
-    return SDL_free(audio_buf);
+    SDL_free(audio_buf);
 }
 
 #ifdef __cplusplus

--- a/src/sdl3_include_wrapper.h
+++ b/src/sdl3_include_wrapper.h
@@ -103,7 +103,6 @@
 #define SDL_PauseAudio IGNORE_THIS_VERSION_OF_SDL_PauseAudio
 #define SDL_PauseAudioDevice IGNORE_THIS_VERSION_OF_SDL_PauseAudioDevice
 #define SDL_LoadWAV_RW IGNORE_THIS_VERSION_OF_SDL_LoadWAV_RW
-#define SDL_FreeWAV IGNORE_THIS_VERSION_OF_SDL_FreeWAV
 #define SDL_BuildAudioCVT IGNORE_THIS_VERSION_OF_SDL_BuildAudioCVT
 #define SDL_ConvertAudio IGNORE_THIS_VERSION_OF_SDL_ConvertAudio
 #define SDL_NewAudioStream IGNORE_THIS_VERSION_OF_SDL_NewAudioStream
@@ -1231,10 +1230,6 @@ typedef void (__cdecl *pfnSDL_CurrentEndThread) (unsigned);
 
 #ifdef SDL_LoadWAV_RW
 #undef SDL_LoadWAV_RW
-#endif
-
-#ifdef SDL_FreeWAV
-#undef SDL_FreeWAV
 #endif
 
 #ifdef SDL_BuildAudioCVT

--- a/src/sdl3_include_wrapper.h
+++ b/src/sdl3_include_wrapper.h
@@ -103,6 +103,7 @@
 #define SDL_PauseAudio IGNORE_THIS_VERSION_OF_SDL_PauseAudio
 #define SDL_PauseAudioDevice IGNORE_THIS_VERSION_OF_SDL_PauseAudioDevice
 #define SDL_LoadWAV_RW IGNORE_THIS_VERSION_OF_SDL_LoadWAV_RW
+#define SDL_FreeWAV IGNORE_THIS_VERSION_OF_SDL_FreeWAV
 #define SDL_BuildAudioCVT IGNORE_THIS_VERSION_OF_SDL_BuildAudioCVT
 #define SDL_ConvertAudio IGNORE_THIS_VERSION_OF_SDL_ConvertAudio
 #define SDL_NewAudioStream IGNORE_THIS_VERSION_OF_SDL_NewAudioStream
@@ -1230,6 +1231,10 @@ typedef void (__cdecl *pfnSDL_CurrentEndThread) (unsigned);
 
 #ifdef SDL_LoadWAV_RW
 #undef SDL_LoadWAV_RW
+#endif
+
+#ifdef SDL_FreeWAV
+#undef SDL_FreeWAV
 #endif
 
 #ifdef SDL_BuildAudioCVT

--- a/src/sdl3_syms.h
+++ b/src/sdl3_syms.h
@@ -107,7 +107,6 @@ SDL3_SYM_PASSTHROUGH(SDL_AudioStatus,GetAudioDeviceStatus,(SDL_AudioDeviceID a),
 SDL3_SYM_PASSTHROUGH(void,PauseAudio,(int a),(a),)
 SDL3_SYM_PASSTHROUGH(void,PauseAudioDevice,(SDL_AudioDeviceID a, int b),(a,b),)
 SDL3_SYM(SDL_AudioSpec*,LoadWAV_RW,(SDL_RWops *a, int b, SDL_AudioSpec *c, Uint8 **d, Uint32 *e),(a,b,c,d,e),return)
-SDL3_SYM_PASSTHROUGH(void,FreeWAV,(Uint8 *a),(a),)
 SDL3_SYM_PASSTHROUGH(int,BuildAudioCVT,(SDL_AudioCVT *a, SDL_AudioFormat b, Uint8 c, int d, SDL_AudioFormat e, Uint8 f, int g),(a,b,c,d,e,f,g),return)
 SDL3_SYM_PASSTHROUGH(int,ConvertAudio,(SDL_AudioCVT *a),(a),return)
 SDL3_SYM_PASSTHROUGH(void,MixAudio,(Uint8 *a, const Uint8 *b, Uint32 c, int d),(a,b,c,d),)


### PR DESCRIPTION
Add back SDL_FreeWAV

but doesn't compile. 
because of SDL_oldnames : 
`#define SDL_FreeWAV SDL_FreeWAV_renamed_SDL_free`

not sure, if we should remove it from SDL3, or change in sdl2-compat