### PR TITLE
internal hint SDL_BORDERLESS_WINDOWED_STYLE

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -1070,6 +1070,7 @@ SDL2Compat_InitOnStartup(void)
 
     SDL3_SetHint("SDL_WINDOWS_DPI_SCALING", 0);
     SDL3_SetHint("SDL_WINDOWS_DPI_AWARENESS", "unaware");
+    SDL3_SetHint("SDL_BORDERLESS_WINDOWED_STYLE", "0");
 
     return okay;
 }


### PR DESCRIPTION
sdl2-compat should set this to "0"