### PR TITLE
Add basic popup support

### DIFF
--- a/src/sdl3_syms.h
+++ b/src/sdl3_syms.h
@@ -483,6 +483,7 @@ SDL3_SYM(const SDL_DisplayMode*,GetCurrentDisplayMode,(SDL_DisplayID a),(a),retu
 SDL3_SYM(int,SetWindowFullscreenMode,(SDL_Window *a, const SDL_DisplayMode *b),(a,b),return)
 SDL3_SYM_PASSTHROUGH(Uint32,GetWindowPixelFormat,(SDL_Window *a),(a),return)
 SDL3_SYM(SDL_Window*,CreateWindow,(const char *a, int b, int c, Uint32 d),(a,b,c,d),return)
+SDL3_SYM(SDL_Window*,CreatePopupWindow,(SDL_Window *a, int b, int c, int d, int e, Uint32 f),(a,b,c,d,e,f),return)
 SDL3_SYM_PASSTHROUGH(SDL_Window*,CreateWindowFrom,(const void *a),(a),return)
 SDL3_SYM_PASSTHROUGH(Uint32,GetWindowID,(SDL_Window *a),(a),return)
 SDL3_SYM_PASSTHROUGH(SDL_Window*,GetWindowFromID,(Uint32 a),(a),return)


### PR DESCRIPTION
Adds basic support for popup windows in SDL2 applications.

The implementation is based on the SDL2 Wayland implementation of popups originally by flibitijibibo, as the cross-platform popup implementation in SDL3 behaves in much the same way with popups being positioned relative to the parent. New popup windows are spawned as children of the window with mouse focus, and tooltips follow the cursor. This is known to be sufficient for Unreal Engine's use of them.

Are there any other known cases of applications using the tooltip or popup menu types with SDL2? If anything was specifically targeting X11 and expects to get a raw window with these flags to be passed through, there may be an issue, but from a cursory search on Github and Google, I can't really find anything. These flags were added for Unreal to begin with and are still tagged 'X11 only' in the SDL2 documentation, so it's doubtful that much else uses them.

If this basic "as required by Unreal" implementation turns out to be insufficient for some purpose, it can always be expanded upon.