### PR TITLE
SDL_ConvertAudio: Fix source/destination format confusion 

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -5503,7 +5503,7 @@ SDL_ConvertAudio(SDL_AudioCVT *cvt)
             (Uint8 *)&cvt->filters[SDL_AUDIOCVT_MAX_FILTERS + 1] - (sizeof(AudioParam) & ~3),
             sizeof(ap));
 
-        src_format = ap.dst_format;
+        src_format = ap.src_format;
         src_channels = ap.src_channels;
         src_rate = ap.src_rate;
         dst_format = ap.dst_format;


### PR DESCRIPTION
The SDL_ConvertAudio() function accidentally uses the destination format as the source format, breaking (presumably amongst other things) 8-bit WAV playback in Uplink under sdl12-compat.

Note that this change is currently based on top of #74, just so it compiles. Only the second commit (with the s/dst_format/src_format) actually matters here.