### PR TITLE
Don't pass removed flags to SDL_CreateRenderer()

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -3246,6 +3246,7 @@ SDL_CreateRenderer(SDL_Window *window, int index, Uint32 flags)
             return NULL;  /* assume SDL3_GetRenderDriver set the SDL error. */
         }
     }
+    flags = flags & ~SDL2_RENDERER_TARGETTEXTURE; /* clear flags removed in SDL3 */
     return SDL3_CreateRenderer(window, name, flags);
 }
 


### PR DESCRIPTION
`SDL_RENDERER_TARGETTEXTURE` was removed in https://github.com/libsdl-org/SDL/commit/dcd17f547324a143d66d79e3b586577a7da558ed

Trying to pass `SDL_RENDERER_TARGETTEXTURE`  to `SDL_CreateRenderer()` result in the following error:  `Couldn't find matching render driver`.

This patch clear the flag before passing it to SDL3. From `SDL_GetRenderDriverInfo()`, I assume this flag is supported by all render, so it is safe to ignore it.