### PR TITLE
ci: only run scheduled build on libsdl-org/sdl2-compat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
   Build:
     name: '${{ matrix.platform.name }}'
     runs-on: '${{ matrix.platform.os }}'
+    # The scheduled event should only run on libsdl-org/sdl2-compat
+    if: ${{ (github.event_name == 'schedule' && github.repository == 'libsdl-org/sdl2-compat') || (github.event_name != 'schedule') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Don't run the daily sdl2-compat build on forks, only run it for `libsdl-org/sdl2-compat`.

I got bothered too much by the nightly build failures due to my sdl2-compat fork becoming incompatible with the unstable SDL3.