### PR TITLE
Translate the SDL2 display index to an SDL3 display ID when setting t…

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -5366,7 +5366,7 @@ SDL_CreateWindow(const char *title, int x, int y, int w, int h, Uint32 flags)
     }
     if (window) {
         if (!SDL_WINDOWPOS_ISUNDEFINED(x) || !SDL_WINDOWPOS_ISUNDEFINED(y)) {
-            SDL3_SetWindowPosition(window, x, y);
+            SDL_SetWindowPosition(window, x, y);
         }
         if (!hidden) {
             SDL3_ShowWindow(window);
@@ -5553,6 +5553,19 @@ SDL_SetWindowPosition(SDL_Window *window, int x, int y)
             y -= y_off;
 
             parent = (SDL_Window *) SDL3_GetWindowData(parent, POPUP_PARENT_PROP_STR);
+        }
+    } else {
+        if (SDL_WINDOWPOS_ISUNDEFINED(x) || SDL_WINDOWPOS_ISCENTERED(x)) {
+            const int displayIndex = x & 0xFFFF;
+            const SDL_DisplayID displayID = Display_IndexToID(displayIndex);
+
+            x = (x & 0xFFFF0000) | (0xFFFF & displayID);
+        }
+        if (SDL_WINDOWPOS_ISUNDEFINED(y) || SDL_WINDOWPOS_ISCENTERED(y)) {
+            const int displayIndex = y & 0xFFFF;
+            const SDL_DisplayID displayID = Display_IndexToID(displayIndex);
+
+            y = (y & 0xFFFF0000) | (0xFFFF & displayID);
         }
     }
 


### PR DESCRIPTION
…he window position

Needed to fix the center window video test and generally place centered/undefined windows on the correct display.