### PR TITLE
Build proper SDL2main for WIndows + test more on ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,16 +16,16 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: 'Linux',                    os: ubuntu-latest,  shell: sh }
-        - { name: 'MacOS',                    os: macos-latest,   shell: sh }
-        - { name: 'Windows msys2 (mingw32)',  os: windows-latest, shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686 }
-        - { name: 'Windows msys2 (mingw64)',  os: windows-latest, shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64 }
-        - { name: 'Windows msys2 (clang32)',  os: windows-latest, shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686 }
-        - { name: 'Windows msys2 (clang64)',  os: windows-latest, shell: 'msys2 {0}', msystem: clang64, msys-env: mingw-w64-clang-x86_64 }
-        - { name: 'Windows MSVC (x86)',       os: windows-latest, shell: sh, msvc: true, msvc-arch: x86 }
-        - { name: 'Windows MSVC (x64)',       os: windows-latest, shell: sh, msvc: true, msvc-arch: x64 }
-        - { name: 'Windows MSVC (arm32)',     os: windows-latest, shell: sh, msvc: true, msvc-arch: amd64_arm, cross: true }
-        - { name: 'Windows MSVC (arm64)',     os: windows-latest, shell: sh, msvc: true, msvc-arch: amd64_arm64, cross: true }
+        - { name: 'Linux',                    os: ubuntu-latest,  artifact: 'SDL2_compat-ubuntu',   shell: sh, static: true }
+        - { name: 'MacOS',                    os: macos-latest,   artifact: 'SDL2_compat-macos',    shell: sh }
+        - { name: 'Windows msys2 (mingw32)',  os: windows-latest, artifact: 'SDL2_compat-mingw32',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686 }
+        - { name: 'Windows msys2 (mingw64)',  os: windows-latest, artifact: 'SDL2_compat-mingw64',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64 }
+        - { name: 'Windows msys2 (clang32)',  os: windows-latest, artifact: 'SDL2_compat-clang32',  shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686 }
+        - { name: 'Windows msys2 (clang64)',  os: windows-latest, artifact: 'SDL2_compat-clang64',  shell: 'msys2 {0}', msystem: clang64, msys-env: mingw-w64-clang-x86_64 }
+        - { name: 'Windows MSVC (x86)',       os: windows-latest, artifact: 'SDL2_compat-VC-x86',   shell: sh, msvc: true, msvc-arch: x86 }
+        - { name: 'Windows MSVC (x64)',       os: windows-latest, artifact: 'SDL2_compat-VC-x64',   shell: sh, msvc: true, msvc-arch: x64 }
+        - { name: 'Windows MSVC (arm32)',     os: windows-latest, artifact: 'SDL2_compat-VC-arm32', shell: sh, msvc: true, msvc-arch: amd64_arm, cross: true }
+        - { name: 'Windows MSVC (arm64)',     os: windows-latest, artifact: 'SDL2_compat-VC-arm64', shell: sh, msvc: true, msvc-arch: amd64_arm64, cross: true }
     defaults:
       run:
         shell: ${{ matrix.platform.shell }}
@@ -65,11 +65,30 @@ jobs:
         sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev
     - name: Configure (CMake)
       run: |
-        cmake -B build -GNinja \
-          -DSDL2COMPAT_WERROR=ON
+        cmake -S . -B build \
+          -DSDL2COMPAT_STATIC=${{ matrix.platform.static }} \
+          -DSDL2COMPAT_INSTALL=TRUE \
+          -DCMAKE_INSTALL_LIBDIR=lib \
+          -DSDL2COMPAT_INSTALL_CPACK=TRUE \
+          -DCMAKE_INSTALL_PREFIX=prefix \
+          -DSDL2COMPAT_WERROR=ON \
+          -DCMAKE_POLICY_DEFAULT_CMP0141="NEW" \
+          -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT="ProgramDatabase" \
+          -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.platform.msvc && '-DEBUG' }}" \
+          -DCMAKE_SHARED_LINKER_FLAGS="${{ matrix.platform.msvc && '-DEBUG' }}" \
+          -GNinja
     - name: Build (CMake)
+      id: build
       run: |
         cmake --build build/ --verbose
+    - name: Install (CMake)
+      run: |
+        cmake --install build/
+        echo "SDL2_ROOT=$(pwd)/prefix" >>$GITHUB_ENV
+    - name: Package (CPack)
+      if: ${{ always() && steps.build.outcome == 'success' }}
+      run: |
+        cmake --build build/ --target package
     - name: Run build-time tests (CMake)
       if: ${{ false && !matrix.platform.cross }} # FIXME: enable build-time tests on CI
       run: |
@@ -93,3 +112,27 @@ jobs:
       if: ${{ runner.os == 'Linux' }}
       run: |
         ./build-scripts/test-versioning.sh
+    - name: Verify CMake configuration files
+      run: |
+        cmake -S cmake/test -B cmake_config_build \
+          -DTEST_SHARED=TRUE \
+          -DTEST_STATIC=${{ matrix.platform.static || 'false' }} \
+          -DCMAKE_BUILD_TYPE=Release \
+          -GNinja
+        cmake --build cmake_config_build --verbose
+    - name: Verify sdl2-config
+      if: ${{ !matrix.platform.msvc }}
+      run: |
+        export PATH=${{ env.SDL2_ROOT }}/bin:$PATH
+        cmake/test/test_sdlconfig.sh ${{ !matrix.platform.static && '--no-static' }}
+    - name: Verify sdl2.pc
+      if: ${{ !matrix.platform.msvc }}
+      run: |
+        export PKG_CONFIG_PATH=${{ env.SDL2_ROOT }}/lib/pkgconfig
+        cmake/test/test_pkgconfig.sh ${{ !matrix.platform.static && '--no-static' }}
+    - uses: actions/upload-artifact@v3
+      if: ${{ always() && steps.build.outcome == 'success' }}
+      with:
+        if-no-files-found: error
+        name: ${{ matrix.platform.artifact }}
+        path: build/dist/SDL2_compat*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,10 @@ if(POLICY CMP0074)
 endif()
 
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  set(SDL2COMPAT_MAINPROJECT ON)
   set(SDL2COMPAT_SUBPROJECT OFF)
 else()
+  set(SDL2COMPAT_MAINPROJECT OFF)
   set(SDL2COMPAT_SUBPROJECT ON)
 endif()
 
@@ -31,6 +33,20 @@ set(SDL_MAJOR_VERSION ${sdl2_compat_VERSION_MAJOR})
 set(SDL_MINOR_VERSION ${sdl2_compat_VERSION_MINOR})
 set(SDL_MICRO_VERSION ${sdl2_compat_VERSION_PATCH})
 set(SDL_VERSION "${SDL_MAJOR_VERSION}.${SDL_MINOR_VERSION}.${SDL_MICRO_VERSION}")
+
+include(CheckCSourceCompiles)
+include(CheckIncludeFile)
+include(CheckCCompilerFlag)
+include(CheckLanguage)
+include(CMakeDependentOption)
+include(CMakePackageConfigHelpers)
+include(CMakeParseArguments)
+include(CMakePushCheckState)
+include(GNUInstallDirs)
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/CheckCPUArchitecture.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlchecks.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlcompilers.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlplatform.cmake")
 
 # Calculate libtool-compatible SO version
 set(SDL_SO_VERSION_MAJOR "0")
@@ -64,27 +80,16 @@ set(SDL_DYLIB_COMPAT_VERSION "${SDL_DYLIB_COMPAT_VERSION_MAJOR}.${SDL_DYLIB_COMP
 
 option(SDL2COMPAT_TESTS "Enable to build SDL2 test programs" ON)
 option(SDL2COMPAT_INSTALL "Enable installating SDL2-compat" ON)
+cmake_dependent_option(SDL2COMPAT_INSTALL_CPACK "Create binary SDL2_compat archive using CPack" ${SDL2COMPAT_MAINPROJECT} "SDL2COMPAT_INSTALL" OFF)
 option(SDL2COMPAT_STATIC "Enable building static SDL2 link library" OFF)
 option(SDL2COMPAT_WERROR "Treat warnings as errors" OFF)
 set(SDL2COMPAT_VENDOR_INFO "" CACHE STRING "Vendor name and/or version to add to SDL_REVISION")
+set(SDL2COMPAT_FRAMEWORK FALSE)
 #FIXME: should SDL2-compat modify vendor_info/revision information?
 
 if(SDL2COMPAT_STATIC AND NOT (CMAKE_SYSTEM_NAME MATCHES "Linux"))
   message(FATAL_ERROR "Static builds are only supported on Linux.")
 endif()
-
-include(CheckCSourceCompiles)
-include(CheckIncludeFile)
-include(CheckCCompilerFlag)
-include(CheckLanguage)
-include(CMakePackageConfigHelpers)
-include(CMakeParseArguments)
-include(CMakePushCheckState)
-include(GNUInstallDirs)
-include("${CMAKE_CURRENT_LIST_DIR}/cmake/CheckCPUArchitecture.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlchecks.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlcompilers.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlplatform.cmake")
 
 SDL_DetectCompiler()
 SDL_DetectCPUArchitecture()
@@ -610,13 +615,13 @@ endif()
 
 if(SDL2COMPAT_INSTALL)
   if(WIN32 AND NOT MINGW)
-    set(SDL23COMPAT_INSTALL_CMAKEDIR_DEFAULT "cmake")
+    set(SDL2COMPAT_INSTALL_CMAKEDIR_DEFAULT "cmake")
     set(LICENSES_PREFIX "licenses/SDL2")
   else()
-    set(SDL23COMPAT_INSTALL_CMAKEDIR_DEFAULT "${CMAKE_INSTALL_LIBDIR}/cmake/SDL2")
+    set(SDL2COMPAT_INSTALL_CMAKEDIR_DEFAULT "${CMAKE_INSTALL_LIBDIR}/cmake/SDL2")
     set(LICENSES_PREFIX "${CMAKE_INSTALL_DATAROOTDIR}/licenses/SDL2")
   endif()
-  set(SDL23COMPAT_INSTALL_CMAKEDIR "${SDL23COMPAT_INSTALL_CMAKEDIR_DEFAULT}" CACHE STRING "Location where to install SDL2Config.cmake")
+  set(SDL2COMPAT_INSTALL_CMAKEDIR "${SDL2COMPAT_INSTALL_CMAKEDIR_DEFAULT}" CACHE STRING "Location where to install SDL2Config.cmake")
 
   list(APPEND installed_targets SDL2main SDL2_test)
   foreach(target ${installed_targets})
@@ -628,12 +633,15 @@ if(SDL2COMPAT_INSTALL)
     install(EXPORT ${target}Targets
       FILE ${target}Targets.cmake
       NAMESPACE SDL2::
-      DESTINATION "${SDL23COMPAT_INSTALL_CMAKEDIR}"
+      DESTINATION "${SDL2COMPAT_INSTALL_CMAKEDIR}"
     )
   endforeach()
+  if(MSVC)
+    install(FILES $<TARGET_PDB_FILE:SDL2> DESTINATION "${CMAKE_INSTALL_BINDIR}" OPTIONAL)
+  endif()
   configure_package_config_file(SDL2Config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/SDL2Config.cmake"
     PATH_VARS CMAKE_INSTALL_PREFIX CMAKE_INSTALL_FULL_BINDIR CMAKE_INSTALL_FULL_INCLUDEDIR CMAKE_INSTALL_FULL_LIBDIR
-    INSTALL_DESTINATION "${SDL23COMPAT_INSTALL_CMAKEDIR}"
+    INSTALL_DESTINATION "${SDL2COMPAT_INSTALL_CMAKEDIR}"
   )
   write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/SDL2ConfigVersion.cmake"
     VERSION ${SDL_VERSION}
@@ -643,7 +651,7 @@ if(SDL2COMPAT_INSTALL)
     FILES
       ${CMAKE_CURRENT_BINARY_DIR}/SDL2Config.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/SDL2ConfigVersion.cmake
-    DESTINATION "${SDL23COMPAT_INSTALL_CMAKEDIR}"
+    DESTINATION "${SDL2COMPAT_INSTALL_CMAKEDIR}"
   )
 
   file(GLOB SDL2_INCLUDE_FILES ${PROJECT_SOURCE_DIR}/include/SDL2/*.h)
@@ -698,10 +706,10 @@ if(SDL2COMPAT_INSTALL)
     configure_file(sdl2_compat.pc.in sdl2_compat.pc @ONLY)
     install(FILES ${CMAKE_BINARY_DIR}/sdl2_compat.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-        )
+      )
 
     configure_file("${CMAKE_SOURCE_DIR}/sdl2-config.in" "${CMAKE_BINARY_DIR}/sdl2-config" @ONLY)
-    install(PROGRAMS "${CMAKE_BINARY_DIR}/sdl2-config" DESTINATION bin)
+    install(PROGRAMS "${CMAKE_BINARY_DIR}/sdl2-config" DESTINATION "${CMAKE_INSTALL_BINDIR}")
   endif()
 
   set(SOEXT ${CMAKE_SHARED_LIBRARY_SUFFIX})
@@ -715,4 +723,20 @@ if(SDL2COMPAT_INSTALL)
   endif()
 
   install(FILES "${PROJECT_SOURCE_DIR}/sdl2.m4" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/aclocal")
+
+  if(SDL2COMPAT_INSTALL_CPACK)
+    if(SDL2COMPAT_FRAMEWORK)
+      set(CPACK_GENERATOR "DragNDrop")
+    elseif(MSVC)
+      set(CPACK_GENERATOR "ZIP")
+    else()
+      set(CPACK_GENERATOR "TGZ")
+    endif()
+    configure_file(cmake/CPackProjectConfig.cmake.in CPackProjectConfig.cmake @ONLY)
+    set(CPACK_PROJECT_CONFIG_FILE "${PROJECT_BINARY_DIR}/CPackProjectConfig.cmake")
+    # CPACK_SOURCE_PACKAGE_FILE_NAME must end with "-src" (so we can block creating a source archive)
+    set(CPACK_SOURCE_PACKAGE_FILE_NAME "SDL${PROJECT_VERSION_MAJOR}-${PROJECT_VERSION}-src")
+    set(CPACK_PACKAGE_DIRECTORY "${CMAKE_BINARY_DIR}/dist")
+    include(CPack)
+  endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,13 +63,13 @@ set(SDL_DYLIB_CURRENT_VERSION "${SDL_DYLIB_CURRENT_VERSION_MAJOR}.${SDL_DYLIB_CU
 set(SDL_DYLIB_COMPAT_VERSION "${SDL_DYLIB_COMPAT_VERSION_MAJOR}.${SDL_DYLIB_COMPAT_VERSION_MINOR}.${SDL_DYLIB_COMPAT_VERSION_MICRO}")
 
 option(SDL2COMPAT_TESTS "Enable to build SDL2 test programs" ON)
-option(SDL2COMPAT_DEVEL "Enable installing SDL2 development headers" ON)
-option(SDL2COMPAT_STATICDEVEL "Enable installing static link library" OFF)
+option(SDL2COMPAT_INSTALL "Enable installating SDL2-compat" ON)
+option(SDL2COMPAT_STATIC "Enable building static SDL2 link library" OFF)
 option(SDL2COMPAT_WERROR "Treat warnings as errors" OFF)
 set(SDL2COMPAT_VENDOR_INFO "" CACHE STRING "Vendor name and/or version to add to SDL_REVISION")
 #FIXME: should SDL2-compat modify vendor_info/revision information?
 
-if(SDL2COMPAT_STATICDEVEL AND NOT (CMAKE_SYSTEM_NAME MATCHES "Linux"))
+if(SDL2COMPAT_STATIC AND NOT (CMAKE_SYSTEM_NAME MATCHES "Linux"))
   message(FATAL_ERROR "Static builds are only supported on Linux.")
 endif()
 
@@ -578,7 +578,7 @@ endif()
 
 set(installed_targets SDL2)
 
-if(SDL2COMPAT_STATICDEVEL AND SDL2COMPAT_DEVEL)
+if(SDL2COMPAT_STATIC)
   add_library(SDL2-static STATIC ${SDL2COMPAT_SRCS})
   add_library(SDL2::SDL2-static ALIAS SDL2-static)
   SDL_AddCommonCompilerFlags(SDL2-static WERROR "${SDL2COMPAT_WERROR}")
@@ -608,7 +608,7 @@ if(SDL2COMPAT_STATICDEVEL AND SDL2COMPAT_DEVEL)
   list(APPEND installed_targets SDL2-static)
 endif()
 
-if(SDL2COMPAT_DEVEL)
+if(SDL2COMPAT_INSTALL)
   if(WIN32 AND NOT MINGW)
     set(SDL23COMPAT_INSTALL_CMAKEDIR_DEFAULT "cmake")
     set(LICENSES_PREFIX "licenses/SDL2")
@@ -679,13 +679,13 @@ if(SDL2COMPAT_DEVEL)
       foreach(lib ${CMAKE_DL_LIBS})
         set(SDL_STATIC_LIBS "-l${lib}")
       endforeach()
-      if(NOT SDL2COMPAT_STATICDEVEL)
+      if(NOT SDL2COMPAT_STATIC)
         set(SDL_STATIC_LIBS "")
       endif()
     endif()
 
     # !!! FIXME: do we _want_ static builds?
-    if(SDL2COMPAT_STATICDEVEL)
+    if(SDL2COMPAT_STATIC)
       set(ENABLE_STATIC_TRUE "")
       set(ENABLE_STATIC_FALSE "#")
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,15 +307,12 @@ endif()
 
 # !!! FIXME: what needs to be done for sdl2-compat? Look into this.
 ## SDL2main library...
-#if(APPLE)
-#    add_library(SDL2main STATIC src/SDLmain/macosx/SDLMain.m)
-#    set_source_files_properties(src/SDLmain/macosx/SDLMain.m PROPERTIES LANGUAGE C)
-#elseif(WIN32)
-#    add_library(SDL2main STATIC src/SDLmain/win32/SDL_win32_main.c)
-#    set_target_properties(SDL2main PROPERTIES COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE")  # !!! FIXME: don't use C runtime? We fixed this in SDL2.
-#else()
+if(WIN32)
+    add_library(SDL2main STATIC src/SDLmain/windows/SDL_windows_main.c)
+    target_link_libraries(SDL2main PRIVATE shell32)
+else()
     add_library(SDL2main STATIC src/SDLmain/dummy/SDL_dummy_main.c)
-#endif()
+endif()
 add_library(SDL2::SDL2main ALIAS SDL2main)
 target_include_directories(SDL2main
     PRIVATE
@@ -667,7 +664,7 @@ if(SDL2COMPAT_DEVEL)
     if(WIN32)
       set(SDL_CFLAGS "")
       set(SDL_RLD_FLAGS "")
-      set(SDL_LIBS "-lmingw32 -lSDL2main -lSDL2 -mwindows")
+      set(SDL_LIBS "-lmingw32 -lSDL2main -lshell32 -lSDL2 -mwindows")
       set(SDL_STATIC_LIBS "")
     elseif(APPLE)
       set(SDL_CFLAGS "-D_THREAD_SAFE")

--- a/cmake/CPackProjectConfig.cmake.in
+++ b/cmake/CPackProjectConfig.cmake.in
@@ -1,0 +1,37 @@
+if(CPACK_PACKAGE_FILE_NAME MATCHES ".*-src$")
+    message(FATAL_ERROR "Creating source archives for SDL@PROJECT_VERSION_MAJOR@_compat @PROJECT_VERSION@ is not supported.")
+endif()
+
+set(PROJECT_SOURCE_DIR "@PROJECT_SOURCE_DIR@")
+set(SDL_CMAKE_PLATFORM "@SDL_CMAKE_PLATFORM@")
+set(SDL_CPU_NAMES "@SDL_CPU_NAMES@")
+list(SORT SDL_CPU_NAMES)
+
+string(REPLACE ";" "-" SDL_CPU_NAMES_WITH_DASHES "${SDL_CPU_NAMES}")
+if(SDL_CPU_NAMES_WITH_DASHES)
+    set(SDL_CPU_NAMES_WITH_DASHES "-${SDL_CPU_NAMES_WITH_DASHES}")
+endif()
+
+string(TOLOWER "${SDL_CMAKE_PLATFORM}" lower_sdl_cmake_platform)
+string(TOLOWER "${SDL_CPU_NAMES}" lower_sdl_cpu_names)
+if(lower_sdl_cmake_platform STREQUAL lower_sdl_cpu_names)
+    set(SDL_CPU_NAMES_WITH_DASHES)
+endif()
+
+set(MSVC @MSVC@)
+set(MINGW @MINGW@)
+if(MSVC)
+    set(SDL_CMAKE_PLATFORM "${SDL_CMAKE_PLATFORM}-VC")
+elseif(MINGW)
+    set(SDL_CMAKE_PLATFORM "${SDL_CMAKE_PLATFORM}-mingw")
+endif()
+
+
+set(CPACK_PACKAGE_FILE_NAME "SDL@PROJECT_VERSION_MAJOR@_compat-@PROJECT_VERSION@-${SDL_CMAKE_PLATFORM}${SDL_CPU_NAMES_WITH_DASHES}")
+
+if(CPACK_GENERATOR STREQUAL "DragNDrop")
+    set(CPACK_DMG_VOLUME_NAME "SDL@PROJECT_VERSION_MAJOR@_compat @PROJECT_VERSION@")
+    # FIXME: no DS_Store file available for sdl2_compat
+    # FIXME: use pre-built/create .DS_Store through AppleScript (CPACK_DMG_DS_STORE/CPACK_DMG_DS_STORE_SETUP_SCRIPT)
+    set(CPACK_DMG_DS_STORE "${PROJECT_SOURCE_DIR}/Xcode/SDL2_compat/pkg-support/resources/SDL_DS_Store")
+endif()

--- a/cmake/test/CMakeLists.txt
+++ b/cmake/test/CMakeLists.txt
@@ -1,0 +1,124 @@
+# This cmake build script is meant for verifying the various CMake configuration script.
+
+cmake_minimum_required(VERSION 3.12)
+project(sdl_test LANGUAGES C)
+
+include(GenerateExportHeader)
+
+if(ANDROID)
+    macro(add_executable NAME)
+        set(args ${ARGN})
+        list(REMOVE_ITEM args WIN32)
+        add_library(${NAME} SHARED ${args})
+        unset(args)
+    endmacro()
+endif()
+
+cmake_policy(SET CMP0074 NEW)
+
+# Override CMAKE_FIND_ROOT_PATH_MODE to allow search for SDL2 outside of sysroot
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE NEVER)
+
+include(FeatureSummary)
+
+option(TEST_SHARED "Test linking to shared SDL2 library" ON)
+add_feature_info("TEST_SHARED" TEST_SHARED "Test linking with shared library")
+
+option(TEST_STATIC "Test linking to static SDL2 library" ON)
+add_feature_info("TEST_STATIC" TEST_STATIC "Test linking with static library")
+
+if(TEST_SHARED)
+    find_package(SDL2 REQUIRED CONFIG COMPONENTS SDL2)
+    if(EMSCRIPTEN OR (WIN32 AND NOT WINDOWS_STORE))
+        find_package(SDL2 REQUIRED CONFIG COMPONENTS SDL2main)
+    endif()
+    add_executable(gui-shared WIN32 main_gui.c)
+    if(TARGET SDL2::SDL2main)
+        target_link_libraries(gui-shared PRIVATE SDL2::SDL2main)
+    endif()
+    target_link_libraries(gui-shared PRIVATE SDL2::SDL2)
+    if(WIN32)
+        add_custom_command(TARGET gui-shared POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:SDL2::SDL2>" "$<TARGET_FILE_DIR:gui-shared>"
+        )
+    endif()
+
+    add_library(sharedlib-shared SHARED main_lib.c)
+    target_link_libraries(sharedlib-shared PRIVATE SDL2::SDL2)
+    generate_export_header(sharedlib-shared EXPORT_MACRO_NAME MYLIBRARY_EXPORT)
+    target_compile_definitions(sharedlib-shared PRIVATE "EXPORT_HEADER=\"${CMAKE_CURRENT_BINARY_DIR}/sharedlib-shared_export.h\"")
+    set_target_properties(sharedlib-shared PROPERTIES C_VISIBILITY_PRESET "hidden")
+
+    add_executable(gui-shared-vars WIN32 main_gui.c)
+    target_link_libraries(gui-shared-vars PRIVATE ${SDL2_LIBRARIES})
+    target_include_directories(gui-shared-vars PRIVATE ${SDL2_INCLUDE_DIRS})
+
+    add_executable(cli-shared main_cli.c)
+    target_link_libraries(cli-shared PRIVATE SDL2::SDL2)
+    if(WIN32)
+        add_custom_command(TARGET cli-shared POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:SDL2::SDL2>" "$<TARGET_FILE_DIR:cli-shared>"
+        )
+    endif()
+
+    # SDL2_LIBRARIES does not support creating a cli SDL2 application
+    # (it is possible that SDL2main is a stub, but we don't know for sure)
+    if(NOT TARGET SDL2::SDL2main)
+        add_executable(cli-shared-vars main_cli.c)
+        target_link_libraries(cli-shared-vars PRIVATE ${SDL2_LIBRARIES})
+        target_include_directories(cli-shared-vars PRIVATE ${SDL2_INCLUDE_DIRS})
+    endif()
+
+    add_library(sharedlib-shared-vars SHARED main_lib.c)
+    target_link_libraries(sharedlib-shared-vars PRIVATE ${SDL2_LIBRARIES})
+    target_include_directories(sharedlib-shared-vars PRIVATE ${SDL2_INCLUDE_DIRS})
+    generate_export_header(sharedlib-shared-vars EXPORT_MACRO_NAME MYLIBRARY_EXPORT)
+    target_compile_definitions(sharedlib-shared-vars PRIVATE "EXPORT_HEADER=\"${CMAKE_CURRENT_BINARY_DIR}/sharedlib-shared-vars_export.h\"")
+    set_target_properties(sharedlib-shared-vars PROPERTIES C_VISIBILITY_PRESET "hidden")
+endif()
+
+if(TEST_STATIC)
+    find_package(SDL2 REQUIRED CONFIG COMPONENTS SDL2-static)
+    if(EMSCRIPTEN OR (WIN32 AND NOT WINDOWS_STORE))
+        find_package(SDL2 REQUIRED CONFIG COMPONENTS SDL2main)
+    endif()
+    add_executable(gui-static WIN32 main_gui.c)
+    if(TARGET SDL2::SDL2main)
+        target_link_libraries(gui-static PRIVATE SDL2::SDL2main)
+    endif()
+    target_link_libraries(gui-static PRIVATE SDL2::SDL2-static)
+
+    option(SDL_STATIC_PIC "SDL static library has been built with PIC")
+    if(SDL_STATIC_PIC OR WIN32)
+        add_library(sharedlib-static SHARED main_lib.c)
+        target_link_libraries(sharedlib-static PRIVATE SDL2::SDL2-static)
+        generate_export_header(sharedlib-static EXPORT_MACRO_NAME MYLIBRARY_EXPORT)
+        target_compile_definitions(sharedlib-static PRIVATE "EXPORT_HEADER=\"${CMAKE_CURRENT_BINARY_DIR}/sharedlib-static_export.h\"")
+        set_target_properties(sharedlib-static PROPERTIES C_VISIBILITY_PRESET "hidden")
+    endif()
+
+    add_executable(gui-static-vars WIN32 main_gui.c)
+    target_link_libraries(gui-static-vars PRIVATE ${SDL2MAIN_LIBRARY} ${SDL2_STATIC_LIBRARIES})
+    target_include_directories(gui-static-vars PRIVATE ${SDL2_INCLUDE_DIRS})
+
+    add_executable(cli-static main_cli.c)
+    target_link_libraries(cli-static PRIVATE SDL2::SDL2-static)
+
+    # SDL2_LIBRARIES does not support creating a cli SDL2 application (when SDL2::SDL2main is available)
+    # (it is possible that SDL2main is a stub, but we don't know for sure)
+    if(NOT TARGET SDL2::SDL2main)
+        add_executable(cli-static-vars main_cli.c)
+        target_link_libraries(cli-static-vars PRIVATE ${SDL2_STATIC_LIBRARIES})
+        target_include_directories(cli-static-vars PRIVATE ${SDL2_INCLUDE_DIRS})
+    endif()
+endif()
+
+message(STATUS "SDL2_PREFIX:            ${SDL2_PREFIX}")
+message(STATUS "SDL2_INCLUDE_DIR:       ${SDL2_INCLUDE_DIR}")
+message(STATUS "SDL2_INCLUDE_DIRS:      ${SDL2_INCLUDE_DIRS}")
+message(STATUS "SDL2_LIBRARIES:         ${SDL2_LIBRARIES}")
+message(STATUS "SDL2_STATIC_LIBRARIES:  ${SDL2_STATIC_LIBRARIES}")
+message(STATUS "SDL2MAIN_LIBRARY:       ${SDL2MAIN_LIBRARY}")
+message(STATUS "SDL2TEST_LIBRARY:       ${SDL2TEST_LIBRARY}")
+
+feature_summary(WHAT ALL)

--- a/cmake/test/main_cli.c
+++ b/cmake/test/main_cli.c
@@ -1,0 +1,14 @@
+#define SDL_MAIN_HANDLED
+#include "SDL.h"
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+    SDL_SetMainReady();
+    if (SDL_Init(0) < 0) {
+        fprintf(stderr, "could not initialize sdl2: %s\n", SDL_GetError());
+        return 1;
+    }
+    SDL_Delay(100);
+    SDL_Quit();
+    return 0;
+}

--- a/cmake/test/main_gui.c
+++ b/cmake/test/main_gui.c
@@ -1,0 +1,28 @@
+#include "SDL.h"
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+    SDL_Window *window = NULL;
+    SDL_Surface *screenSurface = NULL;
+    if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+        fprintf(stderr, "could not initialize sdl2: %s\n", SDL_GetError());
+        return 1;
+    }
+    window = SDL_CreateWindow(
+            "hello_sdl2",
+            SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+            640, 480,
+            SDL_WINDOW_SHOWN
+    );
+    if (window == NULL) {
+        fprintf(stderr, "could not create window: %s\n", SDL_GetError());
+        return 1;
+    }
+    screenSurface = SDL_GetWindowSurface(window);
+    SDL_FillRect(screenSurface, NULL, SDL_MapRGB(screenSurface->format, 0xff, 0xff, 0xff));
+    SDL_UpdateWindowSurface(window);
+    SDL_Delay(100);
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+    return 0;
+}

--- a/cmake/test/main_lib.c
+++ b/cmake/test/main_lib.c
@@ -1,0 +1,33 @@
+#include "SDL.h"
+#include <stdio.h>
+
+#include EXPORT_HEADER
+
+#if defined(_WIN32)
+#include <windows.h>
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
+    return TRUE;
+}
+#endif
+
+int MYLIBRARY_EXPORT mylibrary_init(void);
+void MYLIBRARY_EXPORT mylibrary_quit(void);
+int MYLIBRARY_EXPORT mylibrary_work(void);
+
+int mylibrary_init(void) {
+    SDL_SetMainReady();
+    if (SDL_Init(0) < 0) {
+        fprintf(stderr, "could not initialize sdl2: %s\n", SDL_GetError());
+        return 1;
+    }
+    return 0;
+}
+
+void mylibrary_quit(void) {
+    SDL_Quit();
+}
+
+int mylibrary_work(void) {
+    SDL_Delay(100);
+    return 0;
+}

--- a/cmake/test/test_pkgconfig.sh
+++ b/cmake/test/test_pkgconfig.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+if test "x$CC" = "x"; then
+    CC=cc
+fi
+
+machine="$($CC -dumpmachine)"
+case "$machine" in
+    *mingw* )
+        EXEPREFIX=""
+        EXESUFFIX=".exe"
+        ;;
+    *android* )
+        EXEPREFIX="lib"
+        EXESUFFIX=".so"
+        LDFLAGS="$LDFLAGS -shared"
+        ;;
+    * )
+        EXEPREFIX=""
+        EXESUFFIX=""
+        ;;
+esac
+
+set -e
+
+test_static=yes
+if [ "x$1" = "x--no-static" ]; then
+    test_static=no
+fi
+
+# Get the canonical path of the folder containing this script
+testdir=$(cd -P -- "$(dirname -- "$0")" && printf '%s\n' "$(pwd -P)")
+SDL_CFLAGS="$( pkg-config sdl2_compat --cflags )"
+SDL_LDFLAGS="$( pkg-config sdl2_compat --libs )"
+if [ "x$test_static" = "xyes" ]; then
+    SDL_STATIC_LDFLAGS="$( pkg-config sdl2_compat --libs --static )"
+fi
+
+compile_cmd="$CC -c "$testdir/main_gui.c" -o main_gui_pkgconfig.c.o $SDL_CFLAGS $CFLAGS"
+link_cmd="$CC main_gui_pkgconfig.c.o -o ${EXEPREFIX}main_gui_pkgconfig${EXESUFFIX} $SDL_LDFLAGS $LDFLAGS"
+if [ "x$test_static" = "xyes" ]; then
+    static_link_cmd="$CC main_gui_pkgconfig.c.o -o ${EXEPREFIX}main_gui_pkgconfig_static${EXESUFFIX} $SDL_STATIC_LDFLAGS $LDFLAGS"
+fi
+
+echo "-- CC:                 $CC"
+echo "-- CFLAGS:             $CFLAGS"
+echo "-- LDFLASG:            $LDFLAGS"
+echo "-- SDL_CFLAGS:         $SDL_CFLAGS"
+echo "-- SDL_LDFLAGS:        $SDL_LDFLAGS"
+if [ "x$test_static" = "xyes" ]; then
+    echo "-- SDL_STATIC_LDFLAGS: $SDL_STATIC_LDFLAGS"
+fi
+
+echo "-- COMPILE:       $compile_cmd"
+echo "-- LINK:          $link_cmd"
+if [ "x$test_static" = "xyes" ]; then
+    echo "-- STATIC_LINK:   $static_link_cmd"
+fi
+
+set -x
+
+$compile_cmd
+$link_cmd
+if [ "x$test_static" = "xyes" ]; then
+    $static_link_cmd
+fi

--- a/cmake/test/test_sdlconfig.sh
+++ b/cmake/test/test_sdlconfig.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+if test "x$CC" = "x"; then
+    CC=cc
+fi
+
+machine="$($CC -dumpmachine)"
+case "$machine" in
+    *mingw* )
+        EXEPREFIX=""
+        EXESUFFIX=".exe"
+        ;;
+    *android* )
+        EXEPREFIX="lib"
+        EXESUFFIX=".so"
+        LDFLAGS="$LDFLAGS -shared"
+        ;;
+    * )
+        EXEPREFIX=""
+        EXESUFFIX=""
+        ;;
+esac
+
+set -e
+
+test_static=yes
+if [ "x$1" = "x--no-static" ]; then
+    test_static=no
+fi
+
+# Get the canonical path of the folder containing this script
+testdir=$(cd -P -- "$(dirname -- "$0")" && printf '%s\n' "$(pwd -P)")
+SDL_CFLAGS="$( sdl2-config --cflags )"
+SDL_LDFLAGS="$( sdl2-config --libs )"
+if [ "x$test_static" = "xyes" ]; then
+    SDL_STATIC_LDFLAGS="$( sdl2-config --static-libs )"
+fi
+
+compile_cmd="$CC -c "$testdir/main_gui.c" -o main_gui_sdlconfig.c.o $CFLAGS $SDL_CFLAGS"
+link_cmd="$CC main_gui_sdlconfig.c.o -o ${EXEPREFIX}main_gui_sdlconfig${EXESUFFIX} $SDL_LDFLAGS $LDFLAGS"
+if [ "x$test_static" = "xyes" ]; then
+    static_link_cmd="$CC main_gui_sdlconfig.c.o -o ${EXEPREFIX}main_gui_sdlconfig_static${EXESUFFIX} $SDL_STATIC_LDFLAGS $LDFLAGS"
+fi
+
+echo "-- CC:                 $CC"
+echo "-- CFLAGS:             $CFLAGS"
+echo "-- LDFLAGS:            $LDFLAGS"
+echo "-- SDL_CFLAGS:         $SDL_CFLAGS"
+echo "-- SDL_LDFLAGS:        $SDL_LDFLAGS"
+if [ "x$test_static" = "xyes" ]; then
+    echo "-- SDL_STATIC_LDFLAGS: $SDL_STATIC_LDFLAGS"
+fi
+
+echo "-- COMPILE:       $compile_cmd"
+echo "-- LINK:          $link_cmd"
+if [ "x$test_static" = "xyes" ]; then
+    echo "-- STATIC_LINK:   $static_link_cmd"
+fi
+
+set -x
+
+$compile_cmd
+$link_cmd
+if [ "x$test_static" = "xyes" ]; then
+    $static_link_cmd
+fi

--- a/sdl2_compat.pc.in
+++ b/sdl2_compat.pc.in
@@ -11,4 +11,4 @@ Version: @PROJECT_VERSION@
 Provides: sdl2 = @PROJECT_VERSION@
 Libs: -L${libdir} @SDL_RLD_FLAGS@ @SDL_LIBS@
 @ENABLE_STATIC_TRUE@Libs.private: -L${libdir} @SDL_LIBS@ @SDL_STATIC_LIBS@
-Cflags: -I${includedir}/SDL2 @SDL_CFLAGS@
+Cflags: -I${includedir} -I${includedir}/SDL2 @SDL_CFLAGS@

--- a/src/SDLmain/windows/SDL_windows_main.c
+++ b/src/SDLmain/windows/SDL_windows_main.c
@@ -1,0 +1,126 @@
+/*
+    SDL_windows_main.c, placed in the public domain by Sam Lantinga  4/13/98
+
+    The WinMain function -- calls your program's main() function
+*/
+#include "SDL_config.h"
+
+#ifndef UNICODE
+#define UNICODE 1
+#endif
+
+#include <windows.h>
+#include <shellapi.h> /* CommandLineToArgvW() */
+
+#define WIN_StringToUTF8W(S) SDL_iconv_string("UTF-8", "UTF-16LE", (const char *)(S), (SDL_wcslen(S) + 1) * sizeof(WCHAR))
+
+/* See https://github.com/libsdl-org/SDL/pull/7607  */
+/* force_align_arg_pointer attribute requires gcc >= 4.2.x.  */
+#if defined(__clang__)
+#define HAVE_FORCE_ALIGN_ARG_POINTER
+#elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))
+#define HAVE_FORCE_ALIGN_ARG_POINTER
+#endif
+#if defined(__GNUC__) && defined(__i386__) && defined(HAVE_FORCE_ALIGN_ARG_POINTER)
+#define MINGW32_FORCEALIGN __attribute__((force_align_arg_pointer))
+#else
+#define MINGW32_FORCEALIGN
+#endif
+
+/* Include the SDL main definition header */
+#include "SDL.h"
+#include "SDL_main.h"
+
+#ifdef main
+#undef main
+#endif /* main */
+
+/* Pop up an out of memory message, returns to Windows */
+static BOOL OutOfMemory(void)
+{
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error", "Out of memory - aborting", NULL);
+    return FALSE;
+}
+
+#if defined(_MSC_VER)
+/* The VC++ compiler needs main/wmain defined */
+#define console_ansi_main main
+#if UNICODE
+#define console_wmain wmain
+#endif
+#endif
+
+/* Gets the arguments with GetCommandLine, converts them to argc and argv
+   and calls SDL_main */
+static int main_getcmdline(void)
+{
+    LPWSTR *argvw;
+    char **argv;
+    int i, argc, result;
+
+    argvw = CommandLineToArgvW(GetCommandLineW(), &argc);
+    if (argvw == NULL) {
+        return OutOfMemory();
+    }
+
+    /* Note that we need to be careful about how we allocate/free memory here.
+     * If the application calls SDL_SetMemoryFunctions(), we can't rely on
+     * SDL_free() to use the same allocator after SDL_main() returns.
+     */
+
+    /* Parse it into argv and argc */
+    argv = (char **)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (argc + 1) * sizeof(*argv));
+    if (argv == NULL) {
+        return OutOfMemory();
+    }
+    for (i = 0; i < argc; ++i) {
+        DWORD len;
+        char *arg = WIN_StringToUTF8W(argvw[i]);
+        if (arg == NULL) {
+            return OutOfMemory();
+        }
+        len = (DWORD)SDL_strlen(arg);
+        argv[i] = (char *)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (size_t)len + 1);
+        if (!argv[i]) {
+            return OutOfMemory();
+        }
+        SDL_memcpy(argv[i], arg, len);
+        SDL_free(arg);
+    }
+    argv[i] = NULL;
+    LocalFree(argvw);
+
+    SDL_SetMainReady();
+
+    /* Run the application main() code */
+    result = SDL_main(argc, argv);
+
+    /* Free argv, to avoid memory leak */
+    for (i = 0; i < argc; ++i) {
+        HeapFree(GetProcessHeap(), 0, argv[i]);
+    }
+    HeapFree(GetProcessHeap(), 0, argv);
+
+    return result;
+}
+
+/* This is where execution begins [console apps, ansi] */
+int console_ansi_main(int argc, char *argv[])
+{
+    return main_getcmdline();
+}
+
+#if UNICODE
+/* This is where execution begins [console apps, unicode] */
+int console_wmain(int argc, wchar_t *wargv[], wchar_t *wenvp)
+{
+    return main_getcmdline();
+}
+#endif
+
+/* This is where execution begins [windowed apps] */
+int WINAPI MINGW32_FORCEALIGN
+WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw) /* NOLINT(readability-inconsistent-declaration-parameter-name) */
+{
+    return main_getcmdline();
+}

--- a/src/version.rc
+++ b/src/version.rc
@@ -20,7 +20,7 @@ BEGIN
             VALUE "FileVersion", "2, 28, 50, 0\0"
             VALUE "InternalName", "SDL\0"
             VALUE "LegalCopyright", "Copyright (C) 2023 Sam Lantinga\0"
-            VALUE "OriginalFilename", "SDL.dll\0"
+            VALUE "OriginalFilename", "SDL2.dll\0"
             VALUE "ProductName", "Simple DirectMedia Layer 2.0 wrapper\0"
             VALUE "ProductVersion", "2, 28, 50, 0\0"
         END

--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -1030,6 +1030,8 @@ run_test(void)
 
 #else /* !(HAVE_LIBUDEV_H || defined(SDL_JOYSTICK_LINUX)) */
 
+#include "SDL.h"
+
 static int
 run_test(void)
 {


### PR DESCRIPTION
While testing `SDL2Config.cmake`, `sdl2.pc` and `sdl2-config` on ci, I encountered link errors targeting Windows:
mingw32:
```
D:/a/_temp/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/13.1.0/../../../../i686-w64-mingw32/bin/ld.exe: D:/a/_temp/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/13.1.0/../../../../lib/libmingw32.a(lib32_libmingw32_a-crtexewin.o): in function `main':
C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexewin.c:67: undefined reference to `WinMain@16'
```
MSVC
```
LINK: command "C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1435~1.322\bin\HostX86\x86\link.exe /nologo CMakeFiles\gui-shared.dir\main_gui.c.obj /out:gui-shared.exe /implib:gui-shared.lib /pdb:gui-shared.pdb /version:0.0 /machine:X86 /INCREMENTAL:NO /subsystem:windows D:\a\sdl2-compat\sdl2-compat\prefix\lib\SDL2main.lib D:\a\sdl2-compat\sdl2-compat\prefix\lib\SDL2.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST:EMBED,ID=1" failed (exit code 1120) with the following output:
MSVCRT.lib(exe_winmain.obj) : error LNK2019: unresolved external symbol _WinMain@16 referenced in function "int __cdecl __scrt_common_main_seh(void)" (?__scrt_common_main_seh@@YAHXZ)
gui-shared.exe : fatal error LNK1120: 1 unresolved externals
```
So I ported over `src/main/windows/SDL_windows_main.c` from SDL2.

The second commit renames the cmake options for building the SDL2 static library, and enabling the install option.
The third commits adds testing of sdl2.pc, sdl2-config and SDL2Config.cmake to ci. It also uploads artifacts so people can simply download an archive from the workflows.

