### PR TITLE
SDL_CreateWindowFrom() now takes a set of properties that describe the native window and options.

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -5527,6 +5527,40 @@ SDL_CreateWindow(const char *title, int x, int y, int w, int h, Uint32 flags)
 }
 
 DECLSPEC SDL_Window * SDLCALL
+SDL_CreateWindowFrom(const void *data)
+{
+    SDL_Window *window;
+    const char *hint;
+    SDL_PropertiesID props = SDL3_CreateProperties();
+    if (!props) {
+        return NULL;
+    }
+
+    hint = SDL3_GetHint("SDL_VIDEO_WINDOW_SHARE_PIXEL_FORMAT");
+    if (hint) {
+        /* This hint is a pointer (in string form) of the address of
+           the window to share a pixel format with
+        */
+        SDL_Window *otherWindow = NULL;
+        (void)SDL3_sscanf(hint, "%p", (void **)&otherWindow);
+        SDL3_SetProperty(props, "win32.pixel_format_hwnd", SDL3_GetProperty(SDL3_GetWindowProperties(otherWindow), "SDL.window.win32.hwnd", NULL));
+        SDL3_SetBooleanProperty(props, "opengl", SDL_TRUE);
+    }
+
+    if (SDL3_GetHintBoolean("SDL_VIDEO_FOREIGN_WINDOW_OPENGL", SDL_FALSE)) {
+        SDL3_SetBooleanProperty(props, "opengl", SDL_TRUE);
+    }
+    if (SDL3_GetHintBoolean("SDL_VIDEO_FOREIGN_WINDOW_VULKAN", SDL_FALSE)) {
+        SDL3_SetBooleanProperty(props, "vulkan", SDL_TRUE);
+    }
+
+    SDL3_SetProperty(props, "data", (void *)data);
+    window = SDL3_CreateWindowFrom(props);
+    SDL3_DestroyProperties(props);
+    return window;
+}
+
+DECLSPEC SDL_Window * SDLCALL
 SDL_CreateShapedWindow(const char *title, unsigned int x, unsigned int y, unsigned int w, unsigned int h, Uint32 flags)
 {
     SDL_Window *window;

--- a/src/sdl3_include_wrapper.h
+++ b/src/sdl3_include_wrapper.h
@@ -989,6 +989,8 @@
 #define SDL_GetNumberProperty IGNORE_THIS_VERSION_OF_SDL_GetNumberProperty
 #define SDL_GetFloatProperty IGNORE_THIS_VERSION_OF_SDL_GetFloatProperty
 #define SDL_EnumerateProperties IGNORE_THIS_VERSION_OF_SDL_EnumerateProperties
+#define SDL_SetBooleanProperty IGNORE_THIS_VERSION_OF_SDL_SetBooleanProperty
+#define SDL_GetBooleanProperty IGNORE_THIS_VERSION_OF_SDL_GetBooleanProperty
 
 
 #define SDL_FUNCTION_POINTER_IS_VOID_POINTER 1
@@ -4859,6 +4861,14 @@
 
 #ifdef SDL_EnumerateProperties
 #undef SDL_EnumerateProperties
+#endif
+
+#ifdef SDL_SetBooleanProperty
+#undef SDL_SetBooleanProperty
+#endif
+
+#ifdef SDL_GetBooleanProperty
+#undef SDL_GetBooleanProperty
 #endif
 
 /* undefine these macros too: */

--- a/src/sdl3_syms.h
+++ b/src/sdl3_syms.h
@@ -450,7 +450,7 @@ SDL3_SYM(int,SetWindowFullscreenMode,(SDL_Window *a, const SDL_DisplayMode *b),(
 SDL3_SYM_PASSTHROUGH(Uint32,GetWindowPixelFormat,(SDL_Window *a),(a),return)
 SDL3_SYM(SDL_Window*,CreateWindow,(const char *a, int b, int c, Uint32 d),(a,b,c,d),return)
 SDL3_SYM(SDL_Window*,CreatePopupWindow,(SDL_Window *a, int b, int c, int d, int e, Uint32 f),(a,b,c,d,e,f),return)
-SDL3_SYM_PASSTHROUGH(SDL_Window*,CreateWindowFrom,(const void *a),(a),return)
+SDL3_SYM(SDL_Window*,CreateWindowFrom,(SDL_PropertiesID a),(a),return)
 SDL3_SYM_PASSTHROUGH(Uint32,GetWindowID,(SDL_Window *a),(a),return)
 SDL3_SYM_PASSTHROUGH(SDL_Window*,GetWindowFromID,(Uint32 a),(a),return)
 SDL3_SYM(Uint32,GetWindowFlags,(SDL_Window *a),(a),return)
@@ -897,6 +897,9 @@ SDL3_SYM(SDL_PropertiesID,GetRendererProperties,(SDL_Renderer *a),(a),return)
 SDL3_SYM(SDL_GamepadButtonLabel,GetGamepadButtonLabelForType,(SDL_GamepadType a, SDL_GamepadButton b),(a,b),return)
 SDL3_SYM(SDL_GamepadButtonLabel,GetGamepadButtonLabel,(SDL_Gamepad *a, SDL_GamepadButton b),(a,b),return)
 SDL3_SYM(Sint64,GetNumberProperty,(SDL_PropertiesID a, const char *b, Sint64 c),(a,b,c),return)
+SDL3_SYM(SDL_PropertiesID,CreateProperties,(void),(),return)
+SDL3_SYM(int,SetBooleanProperty,(SDL_PropertiesID a, const char *b, SDL_bool c),(a,b,c),return)
+SDL3_SYM(void,DestroyProperties,(SDL_PropertiesID a),(a),)
 
 #undef SDL3_SYM
 #undef SDL3_SYM_PASSTHROUGH


### PR DESCRIPTION
sdl2-compat changes for https://github.com/libsdl-org/SDL/pull/8548