### PR TITLE
Fix compilation

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -343,8 +343,10 @@ static QuirkEntryType quirks[] = {
 
 #ifdef __linux__
 static void OS_GetExeName(char *buf, const unsigned maxpath) {
+    int ret;
     buf[0] = '\0';
-    readlink("/proc/self/exe", buf, maxpath);
+    ret = readlink("/proc/self/exe", buf, maxpath);
+    (void)ret;
 }
 #elif defined(_WIN32)
 static void OS_GetExeName(char *buf, const unsigned maxpath) {

--- a/test/testautomation_platform.c
+++ b/test/testautomation_platform.c
@@ -386,7 +386,7 @@ int platform_testSetErrorEmptyInput(void *arg)
 int platform_testSetErrorInvalidInput(void *arg)
 {
     int result;
-    const char *invalidError = NULL;
+    const char *invalidError = "";
     const char *probeError = "Testing";
     char *lastError;
     size_t len;


### PR DESCRIPTION
Fix compilation

```
sdl2_compat.c:347:11: error: ignoring return value of ‘readlink’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]
  347 |     (void)readlink("/proc/self/exe", buf, maxpath);
```
```

  test/testautomation_platform.c: In function ‘platform_testSetErrorEmptyInput’:
test/testautomation_platform.c:351:28: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  351 |     result = SDL_SetError("%s", testError);
      |                            ^~
test/testautomation_platform.c:364:64: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  364 |                             "SDL_GetError(): expected message '%s', was message: '%s'",
```