### PR TITLE
README: Don't recommend installing libsdl3-3.0-0, which won't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ you might need to do (!!! FIXME: this won't work until SDL3 is further in
 development!) ...
 
 ```bash
-sudo apt-get install build-essential cmake libsdl3-3.0-0 libsdl3-dev libgl-dev
+sudo apt-get install build-essential cmake libsdl3-dev libgl-dev
 ```
 
 Now just point CMake at sdl2-compat's directory. Here's a command-line


### PR DESCRIPTION
The SONAME of SDL 3 is libSDL3.so.0, so its binary package name in Debian/Ubuntu will be libsdl3-0 as per [Debian Policy §8.1](https://www.debian.org/doc/debian-policy/ch-sharedlibs.html#run-time-shared-libraries) (SDL 2 had a redundant -2.0 in its SONAME, but we dropped that in the SDL 3 branch).

But we don't need to use that name explicitly in any case, because libsdl3-dev depends on the shared library and will pull it in.