### PR TITLE
Optionally install test programs, like we do in SDL2 and SDL3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ set(SDL_DYLIB_CURRENT_VERSION "${SDL_DYLIB_CURRENT_VERSION_MAJOR}.${SDL_DYLIB_CU
 set(SDL_DYLIB_COMPAT_VERSION "${SDL_DYLIB_COMPAT_VERSION_MAJOR}.${SDL_DYLIB_COMPAT_VERSION_MINOR}.${SDL_DYLIB_COMPAT_VERSION_MICRO}")
 
 option(SDL2COMPAT_TESTS "Enable to build SDL2 test programs" ON)
-option(SDL2COMPAT_INSTALL "Enable installating SDL2-compat" ON)
+option(SDL2COMPAT_INSTALL "Enable installing SDL2-compat" ON)
 cmake_dependent_option(SDL2COMPAT_INSTALL_CPACK "Create binary SDL2_compat archive using CPack" ${SDL2COMPAT_MAINPROJECT} "SDL2COMPAT_INSTALL" OFF)
 option(SDL2COMPAT_STATIC "Enable building static SDL2 link library" OFF)
 option(SDL2COMPAT_WERROR "Treat warnings as errors" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SDL_DYLIB_COMPAT_VERSION "${SDL_DYLIB_COMPAT_VERSION_MAJOR}.${SDL_DYLIB_COMP
 option(SDL2COMPAT_TESTS "Enable to build SDL2 test programs" ON)
 option(SDL2COMPAT_INSTALL "Enable installing SDL2-compat" ON)
 cmake_dependent_option(SDL2COMPAT_INSTALL_CPACK "Create binary SDL2_compat archive using CPack" ${SDL2COMPAT_MAINPROJECT} "SDL2COMPAT_INSTALL" OFF)
+cmake_dependent_option(SDL2COMPAT_INSTALL_TESTS "Install test-cases" OFF "SDL2COMPAT_INSTALL;SDL2COMPAT_TESTS" OFF)
 option(SDL2COMPAT_STATIC "Enable building static SDL2 link library" OFF)
 option(SDL2COMPAT_WERROR "Treat warnings as errors" OFF)
 set(SDL2COMPAT_VENDOR_INFO "" CACHE STRING "Vendor name and/or version to add to SDL_REVISION")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,9 @@ if(OPENGL_FOUND)
   endif()
 endif()
 
+set(RESOURCE_FILES)
+set(SDL2COMPAT_TEST_EXECUTABLES)
+
 function(test_program NAME)
   cmake_parse_arguments(args "NONINTERACTIVE" "TIMEOUT" "SRC" ${ARGN})
   if(ANDROID)
@@ -22,6 +25,8 @@ function(test_program NAME)
   else()
     add_executable(${NAME} ${args_SRC})
   endif()
+  list(APPEND SDL2COMPAT_TEST_EXECUTABLES ${NAME})
+  set(SDL2COMPAT_TEST_EXECUTABLES ${SDL2COMPAT_TEST_EXECUTABLES} PARENT_SCOPE)
   SDL_AddCommonCompilerFlags(${NAME} WERROR "${SDL2COMPAT_WERROR}")
   target_link_libraries(${NAME} PRIVATE SDL2::SDL2main SDL2::SDL2test SDL2::SDL2)
   # Turn off MSVC's aggressive C runtime warnings for the old test programs.
@@ -51,6 +56,15 @@ function(test_program NAME)
       ENVIRONMENT "SDL_AUDIODRIVER=dummy;SDL_VIDEODRIVER=dummy"
       TIMEOUT ${timeout}
     )
+    if(SDL2COMPAT_INSTALL_TESTS)
+      set(exe ${NAME})
+      set(installedtestsdir "${CMAKE_INSTALL_FULL_LIBEXECDIR}/installed-tests/SDL2_compat")
+      configure_file(template.test.in "${exe}.test" @ONLY)
+      install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/${exe}.test"
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/installed-tests/SDL2_compat
+      )
+    endif()
   endif()
 endfunction()
 
@@ -190,8 +204,20 @@ foreach(fname
     "testyuv.bmp"
     "unifont-13.0.06.hex"
     "utf8.txt")
+  list(APPEND RESOURCE_FILES "${fname}")
   file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/${fname}" DESTINATION "${CMAKE_BINARY_DIR}")
 endforeach()
+
+if(SDL2COMPAT_INSTALL_TESTS)
+  install(
+    TARGETS ${SDL2COMPAT_TEST_EXECUTABLES}
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/installed-tests/SDL2_compat
+  )
+  install(
+    FILES ${RESOURCE_FILES}
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/installed-tests/SDL2_compat
+  )
+endif()
 
 check_c_compiler_flag(-Wformat HAVE_WFORMAT)
 if(HAVE_WFORMAT)


### PR DESCRIPTION
* build: Fix spelling of "installing"

* build: Allow automated and manual tests to be selected for installation
    
    We'd like to use these as acceptance tests in Debian, as we do for SDL2
    and for SDL3 prereleases. Installing them for "as-installed" testing
    lets Debian's autopkgtest and debci frameworks use our tests to check
    whether a proposed version of one of sdl2-compat's dependencies, for
    example SDL3 or libwayland, would cause sdl2-compat to regress.