### PR TITLE
testautomation_surface: Expect SDL3 error messages

### DIFF
--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -766,7 +766,7 @@ int surface_testOverflow(void *arg)
 
     if (sizeof(size_t) == 4 && sizeof(int) >= 4) {
         SDL_ClearError();
-        expectedError = "Out of memory";
+        expectedError = "aligning pitch would overflow";
         /* 0x5555'5555 * 3bpp = 0xffff'ffff which fits in size_t, but adding
          * alignment padding makes it overflow */
         surface = SDL_CreateRGBSurfaceWithFormat(0, 0x55555555, 1, 24, SDL_PIXELFORMAT_RGB24);
@@ -774,17 +774,20 @@ int surface_testOverflow(void *arg)
         SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
                             "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());
         SDL_ClearError();
+        expectedError = "width * bpp would overflow";
         /* 0x4000'0000 * 4bpp = 0x1'0000'0000 which (just) overflows */
         surface = SDL_CreateRGBSurfaceWithFormat(0, 0x40000000, 1, 32, SDL_PIXELFORMAT_ARGB8888);
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width * bytes per pixel");
         SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
                             "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());
         SDL_ClearError();
+        expectedError = "height * pitch would overflow";
         surface = SDL_CreateRGBSurfaceWithFormat(0, (1 << 29) - 1, (1 << 29) - 1, 8, SDL_PIXELFORMAT_INDEX8);
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width * height");
         SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
                             "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());
         SDL_ClearError();
+        expectedError = "height * pitch would overflow";
         surface = SDL_CreateRGBSurfaceWithFormat(0, (1 << 15) + 1, (1 << 15) + 1, 32, SDL_PIXELFORMAT_ARGB8888);
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width * height * bytes per pixel");
         SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,


### PR DESCRIPTION
In SDL2, overflowing the size_t range was reported as "Out of memory", but in SDL3 it's more specific.

---

Fixes test failure on i386 and other 32-bit architectures (this part of the test is skipped on x86_64).