### PR TITLE
test: Extend testautomation timeout to match classic SDL2

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -155,7 +155,7 @@ if(HAVE_OPENGLES_V2)
   endif()
 endif()
 
-test_program(testautomation NONINTERACTIVE TIMEOUT 40
+test_program(testautomation NONINTERACTIVE TIMEOUT 120
   SRC
     "testautomation.c"
     "testautomation_audio.c"


### PR DESCRIPTION
With the 40-second limit it times out on Debian armel (ARMv5 softfloat) autobuilders, and on some older/unsupported "ports" architectures.