### PR TITLE
Fix SDL_SetWindowsMessageHook() after SDL3 changes.

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -7852,6 +7852,24 @@ SDL_GetThreadID(SDL_Thread *thread)
     return (unsigned long)SDL3_GetThreadID(thread);
 }
 
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_GDK)
+static SDL2_WindowsMessageHook g_WindowsMessageHook = NULL;
+
+static SDL_bool SDLCALL SDL3to2_WindowsMessageHook(void *userdata, MSG *msg)
+{
+    g_WindowsMessageHook(userdata, msg->hwnd, msg->message, msg->wParam, msg->lParam);
+    return SDL_TRUE;
+}
+
+DECLSPEC void SDLCALL
+SDL_SetWindowsMessageHook(SDL2_WindowsMessageHook callback, void *userdata)
+{
+    SDL_WindowsMessageHook callback3 = (callback != NULL) ? SDL3to2_WindowsMessageHook : NULL;
+    g_WindowsMessageHook = callback;
+    SDL3_SetWindowsMessageHook(callback3, userdata);
+}
+#endif
+
 #if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
 DECLSPEC int SDLCALL
 SDL_Direct3D9GetAdapterIndex(int displayIndex)

--- a/src/sdl2_compat.h
+++ b/src/sdl2_compat.h
@@ -181,6 +181,9 @@ typedef struct IDirect3DDevice9 IDirect3DDevice9;
 typedef struct ID3D11Device ID3D11Device;
 typedef struct ID3D12Device ID3D12Device;
 #endif
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_GDK)
+typedef void (SDLCALL * SDL2_WindowsMessageHook)(void *userdata, void *hWnd, unsigned int message, Uint64 wParam, Sint64 lParam);
+#endif
 
 /* SDL2 SysWM mapping */
 typedef enum

--- a/src/sdl2_protos.h
+++ b/src/sdl2_protos.h
@@ -613,7 +613,7 @@ SDL2_PROTO(Uint32,GetQueuedAudioSize,(SDL_AudioDeviceID a))
 SDL2_PROTO(void,ClearQueuedAudio,(SDL_AudioDeviceID a))
 SDL2_PROTO(SDL_Window*,GetGrabbedWindow,(void))
 #if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_GDK)
-SDL2_PROTO(void,SetWindowsMessageHook,(SDL_WindowsMessageHook a, void *b))
+SDL2_PROTO(void,SetWindowsMessageHook,(SDL2_WindowsMessageHook a, void *b))
 #endif
 SDL2_PROTO(int,GetDisplayDPI,(int a, float *b, float *c, float *d))
 SDL2_PROTO(SDL_JoystickPowerLevel,JoystickCurrentPowerLevel,(SDL_Joystick *a))

--- a/src/sdl3_syms.h
+++ b/src/sdl3_syms.h
@@ -47,7 +47,8 @@ SDL3_SYM_VARARGS(int,sscanf,(const char *a, SDL_SCANF_FORMAT_STRING const char *
 SDL3_SYM_VARARGS(int,snprintf,(SDL_OUT_Z_CAP(b) char *a, size_t b, SDL_PRINTF_FORMAT_STRING const char *c, ...))
 
 #if (defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_GDK)) && !defined(SDL_PLATFORM_WINRT)
-SDL3_SYM_PASSTHROUGH(SDL_Thread*,CreateThreadWithStackSize,(SDL_ThreadFunction a, const char *b, const size_t c, void *d, pfnSDL_CurrentBeginThread e, pfnSDL_CurrentEndThread f),(a,b,c,d,e,f),return)
+SDL3_SYM_PASSTHROUGH(SDL_Thread*,CreateThreadWithStackSize,(SDL_ThreadFunction a, const char *b, const size_t c, void *d,
+                                                              pfnSDL_CurrentBeginThread e, pfnSDL_CurrentEndThread f),(a,b,c,d,e,f),return)
 #else
 SDL3_SYM_PASSTHROUGH(SDL_Thread*,CreateThreadWithStackSize,(SDL_ThreadFunction a, const char *b, const size_t c, void *d),(a,b,c,d),return)
 #endif
@@ -55,7 +56,7 @@ SDL3_SYM_PASSTHROUGH(SDL_Thread*,CreateThreadWithStackSize,(SDL_ThreadFunction a
 #if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_GDK)
 SDL3_SYM_PASSTHROUGH(int,RegisterApp,(const char *a, Uint32 b, void *c),(a,b,c),return)
 SDL3_SYM_PASSTHROUGH(void,UnregisterApp,(void),(),)
-SDL3_SYM_PASSTHROUGH(void,SetWindowsMessageHook,(SDL_WindowsMessageHook a, void *b),(a,b),)
+SDL3_SYM(void,SetWindowsMessageHook,(SDL_WindowsMessageHook a, void *b),(a,b),)
 #endif
 
 #if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)


### PR DESCRIPTION
Fixes https://github.com/libsdl-org/sdl2-compat/issues/143

@slouken: Please review. Returning SDL_TRUE is the correct behavior, yes?