### PR TITLE
Handle distinction between full-screen and full-screen desktop

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -5688,10 +5688,16 @@ ApplyFullscreenMode(SDL_Window *window)
     } else {
         int count = 0;
         const SDL_DisplayMode **list;
+        SDL_DisplayID displayID;
         int ret;
 
+        displayID = SDL3_GetDisplayForWindow(window);
+        if (!displayID) {
+            displayID = SDL3_GetPrimaryDisplay();
+        }
+
         /* FIXME: at least set a valid fullscreen mode */
-        list = SDL3_GetFullscreenDisplayModes(SDL3_GetPrimaryDisplay(), &count);
+        list = SDL3_GetFullscreenDisplayModes(displayID, &count);
         if (list && count) {
             ret = SDL3_SetWindowFullscreenMode(window, list[0]);
         } else {
@@ -5721,9 +5727,14 @@ SDL_GetWindowDisplayMode(SDL_Window *window, SDL2_DisplayMode *mode)
     if (dp) {
         DisplayMode_3to2(dp, mode);
     } else {
+        SDL_DisplayID displayID = SDL3_GetDisplayForWindow(window);
+        if (!displayID) {
+            displayID = SDL3_GetPrimaryDisplay();
+        }
+
         /* Desktop mode */
         /* FIXME: is this correct ? */
-        dp = SDL3_GetDesktopDisplayMode(SDL3_GetPrimaryDisplay());
+        dp = SDL3_GetDesktopDisplayMode(displayID);
         if (dp == NULL) {
             return -1;
         }


### PR DESCRIPTION
The existing code would always enter full-screen exclusive mode if SDL_SetWindowDisplayMode() was called before SDL_SetWindowFullscreen(), even if the flag value was SDL_WINDOW_FULLSCREEN_DESKTOP.

Likewise, the code would always enter full-screen desktop mode if SDL_SetWindowDisplayMode() wasn't called, even if the caller passed SDL_WINDOW_FULLSCREEN to ask for full-screen exclusive mode.

Since SDL3 uses the presence of a full-screen mode to tell whether to use full-screen exclusive or full-screen desktop mode, we will stash the provided display mode in a property until we know whether the caller actually wants modesetting or not.

While I was here modifying this code, I also fixed some `SDL3_GetPrimaryDisplay()` calls that should have been using `SDL3_GetDisplayForWindow()` instead.