### PR TITLE
Fix mapping between SDL_EventType in SDL3 to SDL_WindowEventID in SDL2

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -1387,20 +1387,47 @@ SDL_PushEvent(SDL2_Event *event2)
 
 static int Display_IDToIndex(SDL_DisplayID displayID);
 
-static Uint8
+static SDL2_WindowEventID
 WindowEventType3To2(Uint32 event_type3)
 {
-    Uint8 event_type2 = (Uint8) (event_type3 - (Uint32) SDL_EVENT_WINDOW_SHOWN + 1);
-
-    /* SDL_EVENT_WINDOW_TAKE_FOCUS (formerly event 528, now SDL_EVENT_WINDOW_HIT_TEST) was removed from SDL3.
-     * SDL_EVENT_WINDOW_HIT_TEST and higher need the offset adjusted by an additional +1 when mapping to SDL2
-     * to account for the difference.
-     */
-    if (event_type3 >= SDL_EVENT_WINDOW_HIT_TEST) {
-        event_type2 += 1;
+    switch (event_type3) {
+    case SDL_EVENT_WINDOW_SHOWN:
+        return SDL_WINDOWEVENT_SHOWN;
+    case SDL_EVENT_WINDOW_HIDDEN:
+        return SDL_WINDOWEVENT_HIDDEN;
+    case SDL_EVENT_WINDOW_EXPOSED:
+        return SDL_WINDOWEVENT_EXPOSED;
+    case SDL_EVENT_WINDOW_MOVED:
+        return SDL_WINDOWEVENT_MOVED;
+    case SDL_EVENT_WINDOW_RESIZED:
+        return SDL_WINDOWEVENT_RESIZED;
+    case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+        return SDL_WINDOWEVENT_SIZE_CHANGED;
+    case SDL_EVENT_WINDOW_MINIMIZED:
+        return SDL_WINDOWEVENT_MINIMIZED;
+    case SDL_EVENT_WINDOW_MAXIMIZED:
+        return SDL_WINDOWEVENT_MAXIMIZED;
+    case SDL_EVENT_WINDOW_RESTORED:
+        return SDL_WINDOWEVENT_RESTORED;
+    case SDL_EVENT_WINDOW_MOUSE_ENTER:
+        return SDL_WINDOWEVENT_ENTER;
+    case SDL_EVENT_WINDOW_MOUSE_LEAVE:
+        return SDL_WINDOWEVENT_LEAVE;
+    case SDL_EVENT_WINDOW_FOCUS_GAINED:
+        return SDL_WINDOWEVENT_FOCUS_GAINED;
+    case SDL_EVENT_WINDOW_FOCUS_LOST:
+        return SDL_WINDOWEVENT_FOCUS_LOST;
+    case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+        return SDL_WINDOWEVENT_CLOSE;
+    case SDL_EVENT_WINDOW_HIT_TEST:
+        return SDL_WINDOWEVENT_HIT_TEST;
+    case SDL_EVENT_WINDOW_ICCPROF_CHANGED:
+        return SDL_WINDOWEVENT_ICCPROF_CHANGED;
+    case SDL_WINDOWEVENT_DISPLAY_CHANGED:
+        return SDL_WINDOWEVENT_DISPLAY_CHANGED;
+    default:
+        return SDL_WINDOWEVENT_NONE;
     }
-
-    return event_type2;
 }
 
 static int SDLCALL

--- a/src/sdl2_compat.h
+++ b/src/sdl2_compat.h
@@ -648,6 +648,34 @@ typedef struct SDL2_Keysym
 #define SDL2_DISPLAYEVENT 0x150
 #define SDL2_WINDOWEVENT 0x200
 
+typedef enum SDL2_WindowEventID
+{
+    SDL_WINDOWEVENT_NONE,           /**< Never used */
+    SDL_WINDOWEVENT_SHOWN,          /**< Window has been shown */
+    SDL_WINDOWEVENT_HIDDEN,         /**< Window has been hidden */
+    SDL_WINDOWEVENT_EXPOSED,        /**< Window has been exposed and should be
+                                         redrawn */
+    SDL_WINDOWEVENT_MOVED,          /**< Window has been moved to data1, data2
+                                     */
+    SDL_WINDOWEVENT_RESIZED,        /**< Window has been resized to data1xdata2 */
+    SDL_WINDOWEVENT_SIZE_CHANGED,   /**< The window size has changed, either as
+                                         a result of an API call or through the
+                                         system or user changing the window size. */
+    SDL_WINDOWEVENT_MINIMIZED,      /**< Window has been minimized */
+    SDL_WINDOWEVENT_MAXIMIZED,      /**< Window has been maximized */
+    SDL_WINDOWEVENT_RESTORED,       /**< Window has been restored to normal size
+                                         and position */
+    SDL_WINDOWEVENT_ENTER,          /**< Window has gained mouse focus */
+    SDL_WINDOWEVENT_LEAVE,          /**< Window has lost mouse focus */
+    SDL_WINDOWEVENT_FOCUS_GAINED,   /**< Window has gained keyboard focus */
+    SDL_WINDOWEVENT_FOCUS_LOST,     /**< Window has lost keyboard focus */
+    SDL_WINDOWEVENT_CLOSE,          /**< The window manager requests that the window be closed */
+    SDL_WINDOWEVENT_TAKE_FOCUS,     /**< Window is being offered a focus (should SetWindowInputFocus() on itself or a subwindow, or ignore) */
+    SDL_WINDOWEVENT_HIT_TEST,       /**< Window had a hit test that wasn't SDL_HITTEST_NORMAL. */
+    SDL_WINDOWEVENT_ICCPROF_CHANGED,/**< The ICC profile of the window's display has changed. */
+    SDL_WINDOWEVENT_DISPLAY_CHANGED /**< Window has been moved to display data1. */
+} SDL2_WindowEventID;
+
 typedef struct SDL2_CommonEvent
 {
     Uint32 type;
@@ -1271,7 +1299,6 @@ struct SDL_SysWMinfo
 };
 
 typedef struct SDL_SysWMinfo SDL_SysWMinfo;
-
 
 #define SDL_NONSHAPEABLE_WINDOW -1
 #define SDL_INVALID_SHAPE_ARGUMENT -2


### PR DESCRIPTION
Don't try to be clever, just use a switch statement so they're not tightly coupled.