### PR TITLE
Restore log priority after SDL_Quit

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -5042,6 +5042,8 @@ SDL_InitSubSystem(Uint32 flags)
 SDL_DECLSPEC void SDLCALL
 SDL_Quit(void)
 {
+    int i;
+    SDL_LogPriority priorities[SDL_LOG_CATEGORY_CUSTOM];
     relative_mouse_mode = SDL2_FALSE;
 
     if (SDL3_WasInit(SDL_INIT_VIDEO)) {
@@ -5089,7 +5091,15 @@ SDL_Quit(void)
         timers = 0;
     }
 
+    for (i = 0; i < SDL_LOG_CATEGORY_CUSTOM; i++) {
+        priorities[i] = SDL3_GetLogPriority(i);
+    }
+
     SDL3_Quit();
+
+    for (i = 0; i < SDL_LOG_CATEGORY_CUSTOM; i++) {
+        SDL3_SetLogPriority(i, priorities[i]);
+    }
 }
 
 SDL_DECLSPEC void SDLCALL


### PR DESCRIPTION
Doing the following in a SDL project:
```c
    SDL_LogSetPriority(SDL_LOG_CATEGORY_TEST, SDL_LOG_PRIORITY_INFO);
    fprintf(stderr, "before: priority=%d\n", SDL_LogGetPriority(SDL_LOG_CATEGORY_TEST));
    SDL_Quit();
    fprintf(stderr, "after: priority=%d\n", SDL_LogGetPriority(SDL_LOG_CATEGORY_TEST));
```
prints (3, 3) in SDL2:
```
before: priority=3
after: priority=3
```
but prints (3, 1) in SDL3 and current sdl2-compat:
```
before: priority=3
after: priority=1
```