### PR TITLE
Add headers available on all platforms

### DIFF
--- a/include/SDL2/SDL_config.h
+++ b/include/SDL2/SDL_config.h
@@ -59,6 +59,15 @@
 
 /* DEFINES ADDED BY SDL2-COMPAT */
 
+#define STDC_HEADERS 1
+#define HAVE_CTYPE_H 1
+#define HAVE_LIMITS_H 1
+#define HAVE_MATH_H 1
+#define HAVE_SIGNAL_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDIO_H 1
+#define HAVE_STRING_H 1
+
 /* Some programs (incorrectly, probably) check defines that aren't available
    with an SDL2 that doesn't have a configure-generated SDL_config.h, so force
    a few that might be important. */

--- a/include/SDL2/SDL_config.h
+++ b/include/SDL2/SDL_config.h
@@ -47,6 +47,8 @@
 #include "SDL_config_emscripten.h"
 #elif defined(__NGAGE__)
 #include "SDL_config_ngage.h"
+#elif defined (__LINUX__) || defined(__FREEBSD__) || defined(__NETBSD__) || defined(__OPENBSD__) || defined(__SOLARIS__)
+#include "SDL_config_unix.h"
 #else
 /* This is a minimal configuration just to get SDL running on new platforms. */
 #include "SDL_config_minimal.h"
@@ -55,46 +57,5 @@
 #ifdef USING_GENERATED_CONFIG_H
 #error Wrong SDL_config.h, check your include path?
 #endif
-
-
-/* DEFINES ADDED BY SDL2-COMPAT */
-
-#define STDC_HEADERS 1
-#define HAVE_CTYPE_H 1
-#define HAVE_LIMITS_H 1
-#define HAVE_MATH_H 1
-#define HAVE_SIGNAL_H 1
-#define HAVE_STDINT_H 1
-#define HAVE_STDIO_H 1
-#define HAVE_STRING_H 1
-
-/* Some programs (incorrectly, probably) check defines that aren't available
-   with an SDL2 that doesn't have a configure-generated SDL_config.h, so force
-   a few that might be important. */
-#ifndef SDL_VIDEO_OPENGL
-#define SDL_VIDEO_OPENGL 1
-#endif
-#if defined(__WIN32__)
-#define SDL_VIDEO_DRIVER_WINDOWS 1
-#endif
-#if defined (__LINUX__) || defined(__FREEBSD__) || defined(__NETBSD__) || defined(__OPENBSD__) || defined(__SOLARIS__)
-#define SDL_VIDEO_DRIVER_X11 1
-#endif
-#if defined(__LINUX__)
-#define SDL_VIDEO_DRIVER_KMSDRM 1
-#define SDL_VIDEO_DRIVER_WAYLAND 1
-#endif
-#if defined(__MACOSX__)
-#define SDL_VIDEO_DRIVER_COCOA 1
-#endif
-#if defined(__IPHONEOS__) || defined(__TVOS__)
-#define SDL_VIDEO_DRIVER_UIKIT 1
-#endif
-#if defined(__ANDROID__)
-#define SDL_VIDEO_DRIVER_ANDROID 1
-#endif
-
-/* END DEFINES ADDED BY SDL2-COMPAT */
-
 
 #endif /* SDL_config_h_ */

--- a/include/SDL2/SDL_config_unix.h
+++ b/include/SDL2/SDL_config_unix.h
@@ -1,0 +1,73 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2025 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_unix_h_
+#define SDL_config_unix_h_
+
+#include "SDL_platform.h"
+
+/* C datatypes */
+#if defined(__LP64__) || defined(_LP64) || defined(_WIN64)
+#define SIZEOF_VOIDP 8
+#else
+#define SIZEOF_VOIDP 4
+#endif
+
+#define HAVE_GCC_ATOMICS 1
+
+/* Useful headers */
+#define STDC_HEADERS 1
+#define HAVE_ALLOCA_H 1
+#define HAVE_CTYPE_H 1
+#define HAVE_FLOAT_H 1
+#define HAVE_ICONV_H 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_LIMITS_H 1
+#define HAVE_MALLOC_H 1
+#define HAVE_MATH_H 1
+#define HAVE_MEMORY_H 1
+#define HAVE_SIGNAL_H 1
+#define HAVE_STDARG_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDIO_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRINGS_H 1
+#define HAVE_STRING_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_WCHAR_H 1
+
+#define SDL_VIDEO_DRIVER_X11 1
+
+#if defined(__LINUX__)
+#define SDL_VIDEO_DRIVER_KMSDRM 1
+#define SDL_VIDEO_DRIVER_WAYLAND 1
+#endif
+
+/* Enable OpenGL support */
+#define SDL_VIDEO_OPENGL 1
+#define SDL_VIDEO_OPENGL_ES 1
+
+/* Enable Vulkan support */
+#if defined(__LINUX__)
+#define SDL_VIDEO_VULKAN 1
+#endif
+
+#endif /* SDL_config_unix_h_ */


### PR DESCRIPTION
This should help with applications building against sdl2-compat and relying on SDL to include stdio.h for example.