### PR TITLE
testautomation: Verify that SIZEOF_VOIDP has been set correctly

### DIFF
--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -5,7 +5,11 @@
 #include <stdio.h>
 
 #include "SDL.h"
+#include "SDL_config.h"
 #include "SDL_test.h"
+
+/* Compile-time assertions: even better than runtime assertions! */
+SDL_COMPILE_TIME_ASSERT(SIZEOF_VOIDP, SIZEOF_VOIDP == sizeof(void *));
 
 /* Test case functions */
 


### PR DESCRIPTION
* testautomation: Verify that SIZEOF_VOIDP has been set correctly
    
    As discussed on #229, if we're going to try to detect this from compiler
    predefined macros like `__LP64__`, we should verify that we've done
    it correctly; otherwise, we could end up incorrectly assuming 32-bit
    pointers on a 64-bit Unix platform that doesn't define `__LP64__`
    (if such a thing exists).
    
    This static assertion succeeds on all Debian architectures where a build
    has been attempted, including all release architectures and several
    unofficial ports. It might fail on non-Linux kernels or non-GNU libc,
    but if it does, our build on those platforms would have been using the
    wrong value for `SIZEOF_VOIDP` already, so it'll only be detecting a
    pre-existing bug.