### PR TITLE
Improve SDL_config_unix.h

### DIFF
--- a/include/SDL2/SDL_config.h
+++ b/include/SDL2/SDL_config.h
@@ -51,6 +51,7 @@
 #include "SDL_config_unix.h"
 #else
 /* This is a minimal configuration just to get SDL running on new platforms. */
+#warning SDL_config.h might be incomplete, good luck
 #include "SDL_config_minimal.h"
 #endif /* platform config */
 

--- a/include/SDL2/SDL_config.h
+++ b/include/SDL2/SDL_config.h
@@ -47,7 +47,7 @@
 #include "SDL_config_emscripten.h"
 #elif defined(__NGAGE__)
 #include "SDL_config_ngage.h"
-#elif defined (__LINUX__) || defined(__FREEBSD__) || defined(__NETBSD__) || defined(__OPENBSD__) || defined(__SOLARIS__)
+#elif defined(__unix__)
 #include "SDL_config_unix.h"
 #else
 /* This is a minimal configuration just to get SDL running on new platforms. */

--- a/include/SDL2/SDL_config_unix.h
+++ b/include/SDL2/SDL_config_unix.h
@@ -31,7 +31,9 @@
 #define SIZEOF_VOIDP 4
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
 #define HAVE_GCC_ATOMICS 1
+#endif
 
 /* Assume that any reasonable Unix platform has Standard C headers */
 #define STDC_HEADERS 1

--- a/include/SDL2/SDL_config_unix.h
+++ b/include/SDL2/SDL_config_unix.h
@@ -25,7 +25,9 @@
 #include "SDL_platform.h"
 
 /* C datatypes */
-#if defined(__LP64__) || defined(_LP64) || defined(_WIN64)
+#if defined(__SIZEOF_POINTER__)
+#define SIZEOF_VOIDP (__SIZEOF_POINTER__)
+#elif defined(__LP64__) || defined(_LP64) || defined(_WIN64)
 #define SIZEOF_VOIDP 8
 #else
 #define SIZEOF_VOIDP 4

--- a/include/SDL2/SDL_config_unix.h
+++ b/include/SDL2/SDL_config_unix.h
@@ -33,26 +33,30 @@
 
 #define HAVE_GCC_ATOMICS 1
 
-/* Useful headers */
+/* Assume that any reasonable Unix platform has Standard C headers */
 #define STDC_HEADERS 1
-#define HAVE_ALLOCA_H 1
 #define HAVE_CTYPE_H 1
 #define HAVE_FLOAT_H 1
-#define HAVE_ICONV_H 1
 #define HAVE_INTTYPES_H 1
 #define HAVE_LIMITS_H 1
-#define HAVE_MALLOC_H 1
 #define HAVE_MATH_H 1
-#define HAVE_MEMORY_H 1
 #define HAVE_SIGNAL_H 1
 #define HAVE_STDARG_H 1
 #define HAVE_STDINT_H 1
 #define HAVE_STDIO_H 1
 #define HAVE_STDLIB_H 1
-#define HAVE_STRINGS_H 1
 #define HAVE_STRING_H 1
-#define HAVE_SYS_TYPES_H 1
 #define HAVE_WCHAR_H 1
+
+/* Assume that any reasonable Unix platform has POSIX headers */
+#define HAVE_ICONV_H 1
+#define HAVE_STRINGS_H 1
+#define HAVE_SYS_TYPES_H 1
+
+/* Non-standardized, but we assume they exist anyway */
+#define HAVE_ALLOCA_H 1
+#define HAVE_MALLOC_H 1
+#define HAVE_MEMORY_H 1
 
 #define SDL_VIDEO_DRIVER_X11 1
 


### PR DESCRIPTION
* SDL_config.h: Assume that Unix platforms define `__unix__`
    
    This is believed to be a predefined macro on all reasonable Unix
    platforms in practice (it's certainly predefined on GNU/Linux).
    We can add some `|| defined(__myplatform__)` as necessary, but
    this way is more readable than listing every Unix we know about
    individually.
    
    https://sourceforge.net/p/predef/wiki/OperatingSystems/ notes that
    "the xlC or the DEC C/C++ compiler" don't define these, but that doesn't
    seem likely to have any practical impact on us.

* SDL_config.h: Add a #warning if we don't recognise the platform
    
    SDL_config_minimal.h is rather minimal, and we probably don't want anyone
    to actually be relying on it.

* SDL_config_unix.h: Describe our basis for assuming that headers exist
    
    Some of these are Standard C, some are POSIX, and a few are non-standard
    but widely available.

* SDL_config_unix.h: Only define HAVE_GCC_ATOMICS for gcc or clang
    
    The gcc atomic operations are a gcc-specific extension, which clang
    implements for compatibility. In the unlikely event that someone compiles
    sdl2-compat with some other compiler, we can't assume their presence.

* SDL_config_unix.h: Try to use `__SIZEOF_POINTER__`, if defined
    
    gcc (and presumably clang) predefines this, and if present, it seems
    reasonable to treat it as authoritative.

---

As discussed in #229. Compiles successfully on my Debian system, otherwise untested.