### PR TITLE
Fix joystick device list before polling event

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -5823,6 +5823,14 @@ SDL_InitSubSystem(Uint32 flags)
                 SDL_GetNumAudioDevices(SDL2_TRUE);
             }
         }
+
+        /* enumerate joysticks and haptics to build device list */
+        if (flags & (SDL_INIT_JOYSTICK | SDL_INIT_GAMEPAD)) {
+            SDL_NumJoysticks();
+        }
+        if (flags & SDL_INIT_HAPTIC) {
+            SDL_NumHaptics();
+        }
     }
     return result;
 }


### PR DESCRIPTION
[sdl-jstest](https://github.com/Grumbel/sdl-jstest/blob/60f6e62109e100b6ef363841b71c2e37ed714d01/src/sdl2-jstest.c#L145) would call `SDL_JoystickOpen()` before polling SDL event. This breaks joystick device list in sdl2-compat and always gets null returned.
Initializing device list in `SDL_init()` would fix it.