### PR TITLE
Fix scaling for legacy programs on wayland

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -1070,6 +1070,7 @@ SDL2Compat_InitOnStartupInternal(void)
     SDL3_SetHint("SDL_WINDOWS_DPI_AWARENESS", "unaware");
     SDL3_SetHint("SDL_BORDERLESS_WINDOWED_STYLE", "0");
     SDL3_SetHint("SDL_VIDEO_SYNC_WINDOW_OPERATIONS", "1");
+    SDL3_SetHint("SDL_VIDEO_WAYLAND_SCALE_TO_DISPLAY","1");
 
     SDL2Compat_InitLogPrefixes();
 

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -1070,7 +1070,11 @@ SDL2Compat_InitOnStartupInternal(void)
     SDL3_SetHint("SDL_WINDOWS_DPI_AWARENESS", "unaware");
     SDL3_SetHint("SDL_BORDERLESS_WINDOWED_STYLE", "0");
     SDL3_SetHint("SDL_VIDEO_SYNC_WINDOW_OPERATIONS", "1");
-    SDL3_SetHint("SDL_VIDEO_WAYLAND_SCALE_TO_DISPLAY","1");
+
+    // Pretend Wayland doesn't have fractional scaling
+    // This is more compatible with applications that have only been tested under X11 without high DPI support
+    // Full discussion is here: https://github.com/libsdl-org/SDL/issues/12158
+    SDL3_SetHint(SDL_HINT_VIDEO_WAYLAND_SCALE_TO_DISPLAY, "1");
 
     SDL2Compat_InitLogPrefixes();
 


### PR DESCRIPTION
I think this is the solution reached after https://github.com/libsdl-org/SDL/issues/12158
Quirks will eventually be added to applications that do not behave well with this