### PR TITLE
Windows are centered in the display usable bounds in SDL3

### DIFF
--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -2024,14 +2024,14 @@ int video_setWindowCenteredOnDisplay(void *arg)
     }
 
     /* Get display bounds */
-    result = SDL_GetDisplayBounds(0 % displayNum, &display0);
+    result = SDL_GetDisplayUsableBounds(0 % displayNum, &display0);
     SDLTest_AssertPass("SDL_GetDisplayBounds()");
     SDLTest_AssertCheck(result == 0, "Verify return value; expected: 0, got: %d", result);
     if (result != 0) {
         return TEST_ABORTED;
     }
 
-    result = SDL_GetDisplayBounds(1 % displayNum, &display1);
+    result = SDL_GetDisplayUsableBounds(1 % displayNum, &display1);
     SDLTest_AssertPass("SDL_GetDisplayBounds()");
     SDLTest_AssertCheck(result == 0, "Verify return value; expected: 0, got: %d", result);
     if (result != 0) {
@@ -2045,7 +2045,7 @@ int video_setWindowCenteredOnDisplay(void *arg)
             int expectedX = 0, expectedY = 0;
             int currentDisplay;
             int expectedDisplay;
-            SDL_Rect expectedDisplayRect;
+            SDL_Rect expectedDisplayRect, expectedFullscreenRect;
             SDL_bool video_driver_is_wayland = SDL_strcmp(SDL_GetCurrentVideoDriver(), "wayland") == 0;
 
             /* xVariation is the display we start on */
@@ -2108,16 +2108,24 @@ int video_setWindowCenteredOnDisplay(void *arg)
             SDL_GetWindowSize(window, &currentW, &currentH);
             SDL_GetWindowPosition(window, &currentX, &currentY);
 
+            /* Get the expected fullscreen rect.
+             * This needs to be queried after window creation and positioning as some drivers can alter the
+             * usable bounds based on the window scaling mode.
+             */
+            result = SDL_GetDisplayBounds(expectedDisplay, &expectedFullscreenRect);
+            SDLTest_AssertPass("SDL_GetDisplayBounds()");
+            SDLTest_AssertCheck(result == 0, "Verify return value; expected: 0, got: %d", result);
+
             if (!video_driver_is_wayland) {
                 SDLTest_AssertCheck(currentDisplay == expectedDisplay, "Validate display index (current: %d, expected: %d)", currentDisplay, expectedDisplay);
             } else {
                 SDLTest_Log("Skipping display index validation: Wayland driver does not support window positioning");
             }
-            SDLTest_AssertCheck(currentW == expectedDisplayRect.w, "Validate width (current: %d, expected: %d)", currentW, expectedDisplayRect.w);
-            SDLTest_AssertCheck(currentH == expectedDisplayRect.h, "Validate height (current: %d, expected: %d)", currentH, expectedDisplayRect.h);
+            SDLTest_AssertCheck(currentW == expectedFullscreenRect.w, "Validate width (current: %d, expected: %d)", currentW, expectedFullscreenRect.w);
+            SDLTest_AssertCheck(currentH == expectedFullscreenRect.h, "Validate height (current: %d, expected: %d)", currentH, expectedFullscreenRect.h);
             if (!video_driver_is_wayland) {
-                SDLTest_AssertCheck(currentX == expectedDisplayRect.x, "Validate x (current: %d, expected: %d)", currentX, expectedDisplayRect.x);
-                SDLTest_AssertCheck(currentY == expectedDisplayRect.y, "Validate y (current: %d, expected: %d)", currentY, expectedDisplayRect.y);
+                SDLTest_AssertCheck(currentX == expectedFullscreenRect.x, "Validate x (current: %d, expected: %d)", currentX, expectedFullscreenRect.x);
+                SDLTest_AssertCheck(currentY == expectedFullscreenRect.y, "Validate y (current: %d, expected: %d)", currentY, expectedFullscreenRect.y);
             } else {
                 SDLTest_Log("Skipping window position validation: Wayland driver does not support window positioning");
             }


### PR DESCRIPTION
This is an intentional behavior change relative to SDL2, so update the test to reflect this.

Fixes https://github.com/libsdl-org/sdl2-compat/issues/207