### PR TITLE
Implement several hints changed/removed in SDL3

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -500,25 +500,6 @@ SDL2Compat_GetExeName(void)
     return exename;
 }
 
-static const char *
-SDL2Compat_GetHint(const char *name)
-{
-    return SDL3_getenv(name);
-}
-
-static bool
-SDL2Compat_GetHintBoolean(const char *name, bool default_value)
-{
-    const char *val = SDL2Compat_GetHint(name);
-
-    if (!val) {
-        return default_value;
-    }
-
-    return (SDL3_atoi(val) != 0);
-}
-
-
 static struct {
     const char *old_hint;
     const char *new_hint;
@@ -4847,7 +4828,7 @@ SDL_CreateRenderer(SDL_Window *window, int idx, Uint32 flags)
     renderer = SDL3_CreateRenderer(window, name);
     props = SDL3_GetRendererProperties(renderer);
     if (props) {
-        SDL3_SetBooleanProperty(props, PROP_RENDERER_BATCHING, SDL2Compat_GetHintBoolean("SDL_RENDER_BATCHING", (name == NULL)));
+        SDL3_SetBooleanProperty(props, PROP_RENDERER_BATCHING, SDL3_GetHintBoolean("SDL_RENDER_BATCHING", (name == NULL)));
     }
     if (flags & SDL2_RENDERER_PRESENTVSYNC) {
         SDL3_SetRenderVSync(renderer, 1);

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -7655,6 +7655,10 @@ SDL_CreateWindow(const char *title, int x, int y, int w, int h, Uint32 flags)
         flags |= SDL_WINDOW_ALWAYS_ON_TOP;
     }
 
+    if ((flags & SDL_WINDOW_HIGH_PIXEL_DENSITY) && SDL3_GetHintBoolean("SDL_VIDEO_HIGHDPI_DISABLED", false)) {
+        flags &= ~SDL_WINDOW_HIGH_PIXEL_DENSITY;
+    }
+
     if (!is_popup) {
         SDL_PropertiesID props = SDL3_CreateProperties();
 


### PR DESCRIPTION
This PR implements:
- `SDL_HINT_VIDEO_HIGHDPI_DISABLED`
- `SDL_HINT_MOUSE_RELATIVE_SCALING`
- `SDL_HINT_WINDOWS_NO_CLOSE_ON_ALT_F4` (inverted from SDL3)

I also removed `SDL2Compat_GetHint()` and `SDL2Compat_GetHintBoolean()` and replaced them with the SDL3 functions directly. `SDL2Compat_GetHint()` was only looking at environment variables, so apps that called `SDL_SetHint()` to adjust `SDL_HINT_RENDER_BATCHING` would not have those changes take effect. `SDL2Compat_GetHintBoolean()` also did not properly handle the hint value `"true"` (returning false in that case).