### PR TITLE
init: Print the required SDL3 version even if a function is unavailable

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -282,6 +282,19 @@ static bool SDL2Compat_strequal(const char *a, const char *b)
     return true;
 }
 
+/* you can use SDL3_strrchr once we're past startup. */
+static char *SDL2Compat_strrchr(const char *string, int c)
+{
+    const char *bufp = string + SDL2Compat_strlen(string);
+    while (bufp >= string) {
+        if (*bufp == c) {
+            return (char *)bufp;
+        }
+        --bufp;
+    }
+    return NULL;
+}
+
 /* log a string using platform-specific code for before SDL3 is fully available. */
 static void SDL2Compat_LogAtStartup(const char *str)
 {
@@ -548,7 +561,7 @@ SDL2Compat_GetExeName(void)
         static char *base_path;
         bool use_base_path = true;
         OS_GetExeName(path_buf, SDL2COMPAT_MAXPATH, &use_base_path);
-        base_path = SDL3_strrchr(path_buf, *DIRSEP);
+        base_path = SDL2Compat_strrchr(path_buf, *DIRSEP);
         if (base_path && use_base_path) {
             /* We have a '\\' component. */
             exename = base_path + 1;

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -834,8 +834,8 @@ LoadSDL3(void)
         if (!okay) {
             SDL2COMPAT_stpcpy(loaderror, "Failed loading SDL3 library.");
         } else {
-            #define SDL3_SYM(rc,fn,params,args,ret) SDL3_##fn = (SDL3_##fn##_t) LoadSDL3Symbol("SDL_" #fn, &okay);
-            #include "sdl3_syms.h"
+            /* Load SDL_GetVersion() alone first to allow us to check and log the required SDL3 version */
+            SDL3_GetVersion = (SDL3_GetVersion_t) LoadSDL3Symbol("SDL_GetVersion", &okay);
             if (okay) {
                 char sdl3verstr[16];
                 char sdl3reqverstr[16];
@@ -891,6 +891,8 @@ LoadSDL3(void)
                     SDL2Compat_ApplyQuirks(force_x11);  /* Apply and maybe print a list of any enabled quirks. */
                 }
             }
+            #define SDL3_SYM(rc,fn,params,args,ret) SDL3_##fn = (SDL3_##fn##_t) LoadSDL3Symbol("SDL_" #fn, &okay);
+            #include "sdl3_syms.h"
             if (!okay) {
                 UnloadSDL3();
             }


### PR DESCRIPTION
This PR moves the loading of most SDL3 symbols after the point where we perform our required version check. In the event that use of a new SDL3 function is added and required by sdl2-compat (like we did in 2.30.54), we want to be able to print the friendly SDL3 required version text rather than just barfing with the name of a missing SDL3 function.

As a side-effect, this strictly enforces the rule of not calling into SDL3 functions (except `SDL_GetVersion()`) during `LoadSDL3()` and exposed one place where we were doing that.

Before:
```
SDL_StretchSurface missing in SDL3 library.
Aborted (core dumped)
```

After:
```
sdl2-compat 2.32.51: SDL3 library is too old (have 3.1.7, but need at least 3.2.4).
Aborted (core dumped)
```