### PR TITLE
Small performance optimizations

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -5222,13 +5222,14 @@ SDL_RenderDrawPoints(SDL_Renderer *renderer,
     SDL_FPoint *fpoints;
     int i;
     int retval;
+    int isstack;
 
     if (points == NULL) {
         SDL3_InvalidParamError("points");
         return -1;
     }
 
-    fpoints = (SDL_FPoint *) SDL3_malloc(sizeof (SDL_FPoint) * count);
+    fpoints = SDL3_small_alloc(SDL_FPoint, count, &isstack);
     if (fpoints == NULL) {
         return -1;
     }
@@ -5240,7 +5241,7 @@ SDL_RenderDrawPoints(SDL_Renderer *renderer,
 
     retval = SDL3_RenderPoints(renderer, fpoints, count) ? 0 : -1;
 
-    SDL3_free(fpoints);
+    SDL3_small_free(fpoints, isstack);
 
     return retval < 0 ? retval : FlushRendererIfNotBatching(renderer);
 }
@@ -5277,6 +5278,7 @@ SDL_RenderDrawLines(SDL_Renderer *renderer, const SDL_Point *points, int count)
     SDL_FPoint *fpoints;
     int i;
     int retval;
+    int isstack;
 
     if (points == NULL) {
         SDL3_InvalidParamError("points");
@@ -5286,7 +5288,7 @@ SDL_RenderDrawLines(SDL_Renderer *renderer, const SDL_Point *points, int count)
         return 0;
     }
 
-    fpoints = (SDL_FPoint *) SDL3_malloc(sizeof (SDL_FPoint) * count);
+    fpoints = SDL3_small_alloc(SDL_FPoint, count, &isstack);
     if (fpoints == NULL) {
         return -1;
     }
@@ -5298,7 +5300,7 @@ SDL_RenderDrawLines(SDL_Renderer *renderer, const SDL_Point *points, int count)
 
     retval = SDL3_RenderLines(renderer, fpoints, count) ? 0 : -1;
 
-    SDL3_free(fpoints);
+    SDL3_small_free(fpoints, isstack);
 
     return retval < 0 ? retval : FlushRendererIfNotBatching(renderer);
 }
@@ -5387,6 +5389,7 @@ SDL_RenderFillRects(SDL_Renderer *renderer, const SDL_Rect *rects, int count)
     SDL_FRect *frects;
     int i;
     int retval;
+    int isstack;
 
     if (rects == NULL) {
         SDL3_InvalidParamError("rects");
@@ -5396,7 +5399,7 @@ SDL_RenderFillRects(SDL_Renderer *renderer, const SDL_Rect *rects, int count)
         return 0;
     }
 
-    frects = (SDL_FRect *) SDL3_malloc(sizeof (SDL_FRect) * count);
+    frects = SDL3_small_alloc(SDL_FRect, count, &isstack);
     if (frects == NULL) {
         return -1;
     }
@@ -5410,7 +5413,7 @@ SDL_RenderFillRects(SDL_Renderer *renderer, const SDL_Rect *rects, int count)
 
     retval = SDL3_RenderFillRects(renderer, frects, count) ? 0 : -1;
 
-    SDL3_free(frects);
+    SDL3_small_free(frects, isstack);
 
     return retval < 0 ? retval : FlushRendererIfNotBatching(renderer);
 }
@@ -5565,7 +5568,7 @@ SDL_RenderGeometryRaw(SDL_Renderer *renderer, SDL_Texture *texture, const float 
         return -1;
     }
 
-    color3 = (SDL_FColor *) SDL3_small_alloc(SDL_FColor, num_vertices, &isstack);
+    color3 = SDL3_small_alloc(SDL_FColor, num_vertices, &isstack);
     if (!color3) {
         SDL3_OutOfMemory();
         return -1;

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -1217,23 +1217,12 @@ SDL_GetErrorMsg(char *errstr, int maxlen)
 SDL_DECLSPEC int SDLCALL
 SDL_SetError(const char *fmt, ...)
 {
-    char ch;
-    char *str = NULL;
-    size_t len = 0;
     va_list ap;
 
     va_start(ap, fmt);
-    len = SDL3_vsnprintf(&ch, 1, fmt, ap);
+    SDL3_SetErrorV(fmt, ap);
     va_end(ap);
 
-    str = (char *) SDL3_malloc(len + 1);
-    if (str) {
-        va_start(ap, fmt);
-        SDL3_vsnprintf(str, len + 1, fmt, ap);
-        va_end(ap);
-        SDL3_SetError("%s", str);
-        SDL3_free(str);
-    }
     return -1;
 }
 

--- a/src/sdl3_syms.h
+++ b/src/sdl3_syms.h
@@ -47,6 +47,7 @@
 #endif
 
 SDL3_SYM_VARARGS(bool,SetError,(SDL_PRINTF_FORMAT_STRING const char *a, ...))
+SDL3_SYM(bool,SetErrorV,(SDL_PRINTF_FORMAT_STRING const char *a, va_list b),(a,b),return);
 SDL3_SYM_VARARGS(void,Log,(SDL_PRINTF_FORMAT_STRING const char *a, ...))
 SDL3_SYM_VARARGS(void,LogVerbose,(int a, SDL_PRINTF_FORMAT_STRING const char *b, ...))
 SDL3_SYM_VARARGS(void,LogDebug,(int a, SDL_PRINTF_FORMAT_STRING const char *b, ...))


### PR DESCRIPTION
This PR has a few minor performance optimizations to reduce calls to `SDL3_malloc()` and avoid unnecessary renderer flushes in `SDL_RenderDrawRects()`.