### PR TITLE
audio: Initialize the audio callback buffer with silence

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -6842,6 +6842,9 @@ static SDL_AudioDeviceID OpenAudioDeviceLocked(const char *devicename, int iscap
             return 0;
         }
 
+        /* Some apps may leave the callback buffer unmodified, so initialize it with silence */
+        SDL3_memset(stream2->callback2_buffer, obtained2->silence, stream2->bytes_per_callbacks);
+
         stream2->callback2 = desired2->callback;
         stream2->callback2_userdata = desired2->userdata;
         if (iscapture) {


### PR DESCRIPTION
Some apps (DeSmuME) won't necessarily write to it like they're supposed to, so we will end up playing uninitialized memory.

Fixes nasty screeching sound when DeSmuME is running without a ROM loaded.