### PR TITLE
Drop some SDL3 events that incorrectly overlap SDL2 events

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -2091,6 +2091,13 @@ EventFilter3to2(void *userdata, SDL_Event *event3)
     SDL2_Event event2;  /* note that event filters do not receive events as const! So we have to convert or copy it for each one! */
     bool post_event = true;
 
+    /* Drop SDL3 events which have no SDL2 equivalent and may incorrectly overlap with SDL2 event numbers. */
+    switch (event3->type) {
+        case SDL_EVENT_KEYBOARD_ADDED: /* Overlaps with SDL_TEXTEDITING_EXT */
+        case SDL_EVENT_KEYBOARD_REMOVED:
+            return false;
+    }
+
     GestureProcessEvent(event3);  /* this might need to generate new gesture events from touch input. */
 
     /* Ensure joystick and haptic IDs are updated before calling Event3to2() */


### PR DESCRIPTION
The SDL3 keyboard added event number overlaps the SDL2 SDL_TEXTEDITING_EXT event, which can cause a client to crash if it tries processing the keyboard added event as an IME text candidate event with no validation.

Just drop the keyboard added/removed events from the queue, as they have no SDL2 equivalent and would only be ignored.

Caught this with the GOG version of VVVVVV, which was crashing on a keyboard added event due to trying to process it as an IME text event and calling strlen with a null string parameter.