### PR TITLE
Improve accuracy of audio/video subsystem init/quit functions

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -6193,7 +6193,10 @@ SDL_AudioInit(const char *driver_name)
 SDL_DECLSPEC void SDLCALL
 SDL_AudioQuit(void)
 {
-    SDL_QuitSubSystem(SDL_INIT_AUDIO);
+    /* SDL_AudioQuit() ignores subsystem refcounting */
+    while (SDL_WasInit(SDL_INIT_AUDIO)) {
+        SDL_QuitSubSystem(SDL_INIT_AUDIO);
+    }
 }
 
 SDL_DECLSPEC int SDLCALL
@@ -6401,7 +6404,10 @@ SDL_VideoInit(const char *driver_name)
 SDL_DECLSPEC void SDLCALL
 SDL_VideoQuit(void)
 {
-    SDL_QuitSubSystem(SDL_INIT_VIDEO);
+    /* SDL_VideoQuit() ignores subsystem refcounting */
+    while (SDL_WasInit(SDL_INIT_VIDEO)) {
+        SDL_QuitSubSystem(SDL_INIT_VIDEO);
+    }
 }
 
 SDL_DECLSPEC int SDLCALL

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -6183,6 +6183,11 @@ SDL_AudioInit(const char *driver_name)
 {
     SynchronizeEnvironmentVariables();
 
+    if (SDL3_GetCurrentAudioDriver()) {
+        /* Shutdown the current driver before starting again */
+        SDL_AudioQuit();
+    }
+
     if (driver_name) {
         SDL3_SetHintWithPriority(SDL_HINT_AUDIO_DRIVER, driver_name, SDL_HINT_OVERRIDE);
     }
@@ -6393,6 +6398,11 @@ SDL_DECLSPEC int SDLCALL
 SDL_VideoInit(const char *driver_name)
 {
     SynchronizeEnvironmentVariables();
+
+    if (SDL3_GetCurrentVideoDriver()) {
+        /* Shutdown the current driver before starting again */
+        SDL_VideoQuit();
+    }
 
     if (driver_name) {
         SDL3_SetHintWithPriority(SDL_HINT_VIDEO_DRIVER, driver_name, SDL_HINT_OVERRIDE);


### PR DESCRIPTION
These weren't quite working like they did in SDL2, particularly around switching drivers by reinitializing and quitting when additional references were present.