### PR TITLE
Fixed SDL_RenderReadPixels when format argument is 0

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -6142,13 +6142,12 @@ SDL_RenderReadPixels(SDL_Renderer * renderer, const SDL_Rect * rect, Uint32 form
    
     if (!format) {
         target = SDL3_GetRenderTarget(renderer);
-        if (!target) {
-            format = SDL3_GetWindowPixelFormat(SDL3_GetPointerProperty(SDL3_GetRendererProperties(renderer), SDL_PROP_RENDERER_WINDOW_POINTER, NULL));
-        }           
-        else {  
+        if (target) {
             format = SDL3_GetNumberProperty(SDL3_GetTextureProperties(target), SDL_PROP_TEXTURE_FORMAT_NUMBER, 0);
-        }       
-    }        
+        } else {
+            format = SDL3_GetWindowPixelFormat((SDL_Window *)SDL3_GetPointerProperty(SDL3_GetRendererProperties(renderer), SDL_PROP_RENDERER_WINDOW_POINTER, NULL));
+        }
+    }
 
     if (SDL3_ConvertPixelsAndColorspace(surface->w, surface->h, surface->format, SDL3_GetSurfaceColorspace(surface), SDL3_GetSurfaceProperties(surface), surface->pixels, surface->pitch, (SDL_PixelFormat)format, SDL_COLORSPACE_SRGB, 0, pixels, pitch)) {
         result = 0;

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -6133,11 +6133,22 @@ SDL_DECLSPEC int SDLCALL
 SDL_RenderReadPixels(SDL_Renderer * renderer, const SDL_Rect * rect, Uint32 format, void *pixels, int pitch)
 {
     int result = -1;
+    SDL_Texture* target;
 
     SDL_Surface *surface = SDL3_RenderReadPixels(renderer, rect);
     if (!surface) {
         return -1;
     }
+   
+    if (!format) {
+        target = SDL3_GetRenderTarget(renderer);
+        if (!target) {
+            format = SDL3_GetWindowPixelFormat(SDL3_GetPointerProperty(SDL3_GetRendererProperties(renderer), SDL_PROP_RENDERER_WINDOW_POINTER, NULL));
+        }           
+        else {  
+            format = SDL3_GetNumberProperty(SDL3_GetTextureProperties(target), SDL_PROP_TEXTURE_FORMAT_NUMBER, 0);
+        }       
+    }        
 
     if (SDL3_ConvertPixelsAndColorspace(surface->w, surface->h, surface->format, SDL3_GetSurfaceColorspace(surface), SDL3_GetSurfaceProperties(surface), surface->pixels, surface->pitch, (SDL_PixelFormat)format, SDL_COLORSPACE_SRGB, 0, pixels, pitch)) {
         result = 0;


### PR DESCRIPTION
This should resolve #406. I tried to match the behavior of SDL2's implementation of [SDL_RenderReadPixels](https://github.com/libsdl-org/SDL/blob/1caae3e9e448e9ec728faa9b13e058f5d63189e0/src/render/SDL_render.c#L4233C1-L4239C6).