### PR TITLE
Install lowercase sdl2-config.cmake and sdl2-config-version.cmake for rpm compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,6 +539,8 @@ if(SDL2COMPAT_INSTALL)
   )
   install(
     FILES
+      cmake/sdl2-config.cmake
+      cmake/sdl2-config-version.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/SDL2Config.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/SDL2ConfigVersion.cmake
     DESTINATION "${SDL2COMPAT_INSTALL_CMAKEDIR}"

--- a/cmake/sdl2-config-version.cmake
+++ b/cmake/sdl2-config-version.cmake
@@ -1,0 +1,3 @@
+# Compatibility for SDL2 built with autotools
+
+include("${CMAKE_CURRENT_LIST_DIR}/SDL2ConfigVersion.cmake")

--- a/cmake/sdl2-config.cmake
+++ b/cmake/sdl2-config.cmake
@@ -1,0 +1,3 @@
+# Compatibility for SDL2 built with autotools
+
+include("${CMAKE_CURRENT_LIST_DIR}/SDL2Config.cmake")

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -6990,7 +6990,7 @@ static int GetNumAudioDevices(int iscapture)
         newlist.num_devices = num_devices;
         newlist.devices = (AudioDeviceInfo *) SDL3_malloc(sizeof (AudioDeviceInfo) * num_devices);
         if (!newlist.devices) {
-            SDL3_free(orignames);
+            SDL3_free((void*) orignames);
             SDL3_free(devices);
             return list->num_devices;  /* just return the existing one for now. Oh well. */
         }
@@ -7030,7 +7030,7 @@ static int GetNumAudioDevices(int iscapture)
                 for (j = 0; j < (i-1); j++) {
                     SDL3_free(newlist.devices[j].name);
                 }
-                SDL3_free(orignames);
+                SDL3_free((void*) orignames);
                 SDL3_free(devices);
                 return list->num_devices;  /* just return the existing one for now. Oh well. */
             }
@@ -7039,7 +7039,7 @@ static int GetNumAudioDevices(int iscapture)
             newlist.devices[i].name = fullname;
         }
 
-        SDL3_free(orignames);
+        SDL3_free((void*) orignames);
     }
 
     for (i = 0; i < list->num_devices; i++) {


### PR DESCRIPTION
Also fix a  "'function': different 'const' qualifiers" warning, seen with MSVC 2019

Fixes #408
