### PR TITLE
render: Don't check for compatible flags with a specified render driver

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -5535,26 +5535,16 @@ SDL_CreateRenderer(SDL_Window *window, int idx, Uint32 flags)
                 SDL3_SetHint(SDL_HINT_RENDER_DRIVER, NULL);
             }
         }
+
+        /* A valid render driver specified by idx or hint takes precedence over flags */
+        if (!name && (flags & SDL2_RENDERER_SOFTWARE)) {
+            name = SDL_SOFTWARE_RENDERER;
+        }
     } else {
         name = SDL3_GetRenderDriver(idx);
         if (!name) {
             return NULL;  /* assume SDL3_GetRenderDriver set the SDL error. */
         }
-    }
-
-    if (flags & SDL2_RENDERER_ACCELERATED) {
-        if (name && SDL3_strcmp(name, SDL_SOFTWARE_RENDERER) == 0) {
-            SDL3_SetError("Couldn't find matching render driver");
-            return NULL;
-        }
-    }
-
-    if (flags & SDL2_RENDERER_SOFTWARE) {
-        if (name && SDL3_strcmp(name, SDL_SOFTWARE_RENDERER) != 0) {
-            SDL3_SetError("Couldn't find matching render driver");
-            return NULL;
-        }
-        name = SDL_SOFTWARE_RENDERER;
     }
 
     renderer = SDL3_CreateRenderer(window, name);


### PR DESCRIPTION
SDL2 only used `SDL_RENDERER_SOFTWARE` and `SDL_RENDERER_ACCELERATED` to select a render driver if none was specified by either hint or idx parameter.

Fixes #414