### PR TITLE
Fix pysdl2 SDL_GetTextureScaleMode test failure

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -214,9 +214,11 @@ do { \
 #define PROP_RENDERER_BATCHING "sdl2-compat.renderer.batching"
 #define PROP_RENDERER_RELATIVE_SCALING "sdl2-compat.renderer.relative-scaling"
 #define PROP_RENDERER_INTEGER_SCALE "sdl2-compat.renderer.integer_scale"
+#define PROP_TEXTURE_SCALE_MODE "sdl2-compat.texture.scale_mode"
 #define PROP_SURFACE2 "sdl2-compat.surface2"
 #define PROP_STREAM2 "sdl2-compat.stream2"
 
+#define PROP_TEXTURE_SCALE_MODE_UNAVAILABLE (-42)
 
 
 static bool WantDebugLogging = false;
@@ -6280,10 +6282,30 @@ SDL_QueryTexture(SDL_Texture *texture, Uint32 *format, int *access, int *w, int 
 SDL_DECLSPEC int SDLCALL
 SDL_SetTextureScaleMode(SDL_Texture *texture, SDL_ScaleMode scaleMode)
 {
+    SDL_PropertiesID props = SDL3_GetTextureProperties(texture);
+    if (props) {
+        SDL3_SetNumberProperty(props, PROP_TEXTURE_SCALE_MODE, scaleMode);
+    }
     if (scaleMode > SDL_SCALEMODE_LINEAR) {
         scaleMode = SDL_SCALEMODE_LINEAR;
     }
     return SDL3_SetTextureScaleMode(texture, scaleMode) ? 0 : -1;
+}
+
+SDL_DECLSPEC int SDLCALL
+SDL_GetTextureScaleMode(SDL_Texture *texture, SDL_ScaleMode *scaleMode)
+{
+    SDL_PropertiesID props = SDL3_GetTextureProperties(texture);
+    if (props) {
+        Sint64 cached_scale_mode = SDL3_GetNumberProperty(props, PROP_TEXTURE_SCALE_MODE, PROP_TEXTURE_SCALE_MODE_UNAVAILABLE);
+        if (cached_scale_mode != PROP_TEXTURE_SCALE_MODE_UNAVAILABLE) {
+            if (scaleMode) {
+                *scaleMode = (SDL_ScaleMode) cached_scale_mode;
+            }
+            return 0;
+        }
+    }
+    return SDL3_GetTextureScaleMode(texture, scaleMode) ? 0 : -1;
 }
 
 SDL_DECLSPEC int SDLCALL

--- a/src/sdl3_syms.h
+++ b/src/sdl3_syms.h
@@ -395,7 +395,7 @@ SDL3_SYM_PASSTHROUGH_RETCODE(bool,GetTextureAlphaMod,(SDL_Texture *a, Uint8 *b),
 SDL3_SYM_PASSTHROUGH_RETCODE(bool,GetTextureBlendMode,(SDL_Texture *a, SDL_BlendMode *b),(a,b),return)
 SDL3_SYM_PASSTHROUGH_RETCODE(bool,GetTextureColorMod,(SDL_Texture *a, Uint8 *b, Uint8 *c, Uint8 *d),(a,b,c,d),return)
 SDL3_SYM(SDL_PropertiesID,GetTextureProperties,(SDL_Texture *a),(a),return)
-SDL3_SYM_PASSTHROUGH_RETCODE(bool,GetTextureScaleMode,(SDL_Texture *a, SDL_ScaleMode *b),(a,b),return)
+SDL3_SYM(bool,GetTextureScaleMode,(SDL_Texture *a, SDL_ScaleMode *b),(a,b),return)
 SDL3_SYM(Uint64,GetThreadID,(SDL_Thread *a),(a),return)
 SDL3_SYM_PASSTHROUGH(const char*,GetThreadName,(SDL_Thread *a),(a),return)
 SDL3_SYM(Uint64,GetTicks,(void),(),return)

--- a/test/testautomation_render.c
+++ b/test/testautomation_render.c
@@ -812,6 +812,46 @@ int render_testBlitBlend(void *arg)
 }
 
 /**
+ * @brief Tests setting and getting texture scale mode.
+ *
+ * \sa
+ * http://wiki.libsdl.org/SDL2/SDL_SetTextureScaleMode
+ * http://wiki.libsdl.org/SDL2/SDL_GetTextureScaleMode
+ */
+int render_testGetSetTextureScaleMode(void *arg)
+{
+    const struct {
+        const char *name;
+        SDL_ScaleMode mode;
+    } modes[] = {
+        { "SDL_ScaleModeNearest", SDL_ScaleModeNearest },
+        { "SDL_ScaleModeLinear",  SDL_ScaleModeLinear },
+        { "SDL_ScaleModeBest",    SDL_ScaleModeBest }
+    };
+    size_t i;
+
+    for (i = 0; i < SDL_arraysize(modes); i++) {
+        SDL_Texture *texture;
+        int result;
+        SDL_ScaleMode actual_mode = SDL_ScaleModeNearest;
+
+        SDL_ClearError();
+        SDLTest_AssertPass("About to call SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 16, 16)");
+        texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 16, 16);
+        SDLTest_AssertCheck(texture != NULL, "SDL_CreateTexture must return a non-NULL texture");
+        SDLTest_AssertPass("About to call SDL_SetTextureScaleMode(texture, %s)", modes[i].name);
+        result = SDL_SetTextureScaleMode(texture, modes[i].mode);
+        SDLTest_AssertCheck(result == 0, "SDL_SetTextureScaleMode must return 0, actual %d", result);
+        SDLTest_AssertPass("About to call SDL_GetTextureScaleMode(texture)");
+        result = SDL_GetTextureScaleMode(texture, &actual_mode);
+        SDLTest_AssertCheck(result == 0, "SDL_SetTextureScaleMode must return 0, actual %d", result);
+        SDLTest_AssertCheck(actual_mode == modes[i].mode, "SDL_GetTextureScaleMode must return %s (%d), actual=%d",
+            modes[i].name, modes[i].mode, actual_mode);
+    }
+    return TEST_COMPLETED;
+}
+
+/**
  * @brief Checks to see if functionality is supported. Helper function.
  */
 static int
@@ -1161,9 +1201,13 @@ static const SDLTest_TestCaseReference renderTest7 = {
     (SDLTest_TestCaseFp)render_testBlitBlend, "render_testBlitBlend", "Tests blitting with blending", TEST_DISABLED
 };
 
+static const SDLTest_TestCaseReference renderTest8 = {
+    (SDLTest_TestCaseFp)render_testGetSetTextureScaleMode, "render_testGetSetTextureScaleMode", "Tests setting/getting texture scale mode", TEST_ENABLED
+};
+
 /* Sequence of Render test cases */
 static const SDLTest_TestCaseReference *renderTests[] = {
-    &renderTest1, &renderTest2, &renderTest3, &renderTest4, &renderTest5, &renderTest6, &renderTest7, NULL
+    &renderTest1, &renderTest2, &renderTest3, &renderTest4, &renderTest5, &renderTest6, &renderTest7, &renderTest8, NULL
 };
 
 /* Render test suite (global) */


### PR DESCRIPTION
Cache the original scale mode as a property on the texture.