### PR TITLE
Prefer X11 for the UE5 editor by default

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -492,6 +492,9 @@ static QuirkEntryType quirks[] = {
 
     /* Stylus Labs Write does its own X11 input handling */
     { "Write", "SDL_VIDEO_X11_XINPUT2", "0" },
+
+    /* The UE5 editor has input issues and broken toast notification positioning on Wayland */
+    { "UnrealEditor", SDL_HINT_VIDEO_DRIVER, "x11" },
 };
 
 #ifdef __linux__


### PR DESCRIPTION
It requires more work before it will work properly on Wayland, as toast popup notifications are broken, some desktops have mouse input issues, and the current Nvidia drivers seem to have stability issues with it when running natively under Wayland (XWayland is fine, though).

Too many issues for now; favor X11/XWayland by default.

Fixes #426 