### PR TITLE
Skip the Jack audio server test

### DIFF
--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -67,6 +67,9 @@ static SDL_bool DriverIsProblematic(const char *driver)
          */
         "dsp",
 
+        /* Jack isn't always configured properly on end user systems */
+        "jack",
+
         /* OpenBSD sound API. Can be used on Linux, but very rare. */
         "sndio",
 


### PR DESCRIPTION
The Jack server might not be running even though the libraries are installed.