### PR TITLE
Revert "Rename sdl2-compat.pc to sdl2.pc (#446)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,8 +599,8 @@ if(SDL2COMPAT_INSTALL)
   set(ENABLE_SHARED_TRUE "")
   set(ENABLE_SHARED_FALSE "#")
 
-  configure_file(sdl2.pc.in sdl2.pc @ONLY)
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sdl2.pc"
+  configure_file(sdl2-compat.pc.in sdl2-compat.pc @ONLY)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sdl2-compat.pc"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
   )
 

--- a/cmake/test/test_pkgconfig.sh
+++ b/cmake/test/test_pkgconfig.sh
@@ -30,10 +30,10 @@ fi
 
 # Get the canonical path of the folder containing this script
 testdir=$(cd -P -- "$(dirname -- "$0")" && printf '%s\n' "$(pwd -P)")
-SDL_CFLAGS="$( pkg-config sdl2 --cflags )"
-SDL_LDFLAGS="$( pkg-config sdl2 --libs )"
+SDL_CFLAGS="$( pkg-config sdl2-compat --cflags )"
+SDL_LDFLAGS="$( pkg-config sdl2-compat --libs )"
 if [ "x$test_static" = "xyes" ]; then
-    SDL_STATIC_LDFLAGS="$( pkg-config sdl2 --libs --static )"
+    SDL_STATIC_LDFLAGS="$( pkg-config sdl2-compat --libs --static )"
 fi
 
 compile_cmd="$CC -c "$testdir/main_gui.c" -o main_gui_pkgconfig.c.o $SDL_CFLAGS $CFLAGS"

--- a/sdl2-compat.pc.in
+++ b/sdl2-compat.pc.in
@@ -8,7 +8,7 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: sdl2_compat
 Description: An SDL2 compatibility layer that uses SDL3 behind the scenes.
 Version: @PROJECT_VERSION@
-Provides: sdl2 = @PROJECT_VERSION@, sdl2-compat = @PROJECT_VERSION@, sdl2_compat = @PROJECT_VERSION@
+Provides: sdl2 = @PROJECT_VERSION@
 Libs: -L${libdir} @SDL_RLD_FLAGS@ @SDL_LIBS@
 @ENABLE_STATIC_TRUE@Libs.private: @SDL_STATIC_LIBS@
 Cflags: -I${includedir} -I${includedir}/SDL2 @SDL_CFLAGS@


### PR DESCRIPTION
This is unnecessary, given that everyone uses `pkgconf(1)`, which fully supports the `Provides:` stanza and expresses it in dependencies.

The issue mentioned in the commit being reverted is a matter of education.

This reverts commit 0bc8d4434fb911973762230bbcf4529f39fb8912.