### PR TITLE
Don't use quirks to force X11 things on non-X11 platforms

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -505,8 +505,10 @@ static QuirkEntryType quirks[] = {
     { "tauon/__main__.py", SDL_HINT_VIDEO_WAYLAND_SCALE_TO_DISPLAY, "0" },
     { "tauon/__main__.py", SDL_HINT_VIDEO_WAYLAND_ALLOW_LIBDECOR, "0" },
 
+#ifdef SDL2COMPAT_HAVE_X11
     /* Stylus Labs Write does its own X11 input handling */
     { "Write", "SDL_VIDEO_X11_XINPUT2", "0" },
+#endif
 
     /* PPSSPP reads fractional values in wheel events */
     { "PPSSPP", "SDL_MOUSE_INTEGER_MODE", "1" },
@@ -515,6 +517,7 @@ static QuirkEntryType quirks[] = {
     /* Lite-XL reads fractional values in wheel events */
     { "lite-xl", "SDL_MOUSE_INTEGER_MODE", "1" },
 
+#ifdef SDL2COMPAT_HAVE_X11
     /* The UE5 editor has input issues and broken toast notification positioning on Wayland */
     { "UnrealEditor", SDL_HINT_VIDEO_DRIVER, "x11" },
 
@@ -533,6 +536,7 @@ static QuirkEntryType quirks[] = {
     { "BaldursGateII", SDL_HINT_VIDEO_DRIVER, "x11" },
     { "IcewindDale", SDL_HINT_VIDEO_DRIVER, "x11" },
     { "Torment64", SDL_HINT_VIDEO_DRIVER, "x11" },
+#endif
 };
 
 #ifdef __linux__

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -111,6 +111,13 @@ This breaks the build when creating SDL_ ## DisableScreenSaver
 #define SDL2COMPAT_MAXPATH 1024
 #endif
 
+#if defined(SDL_PLATFORM_UNIX) && !defined(SDL_PLATFORM_ANDROID)
+/* We don't know whether SDL3 was really compiled with X11 support on this
+ * platform, but probably it was */
+#define SDL2COMPAT_HAVE_X11
+#else
+#undef SDL2COMPAT_HAVE_X11
+#endif
 
 /* SDL2 function prototypes:  */
 #include "sdl2_protos.h"
@@ -10111,7 +10118,7 @@ SDL_SetWindowsMessageHook(SDL2_WindowsMessageHook callback, void *userdata)
 }
 #endif /* SDL_PLATFORM_WINDOWS */
 
-#if defined(SDL_PLATFORM_UNIX) && !defined(SDL_PLATFORM_ANDROID)
+#ifdef SDL2COMPAT_HAVE_X11
 static bool SDLCALL SDL2COMPAT_X11EventHook(void *userdata, XEvent *xevent)
 {
     SDL2_Event event;
@@ -10127,7 +10134,7 @@ static bool SDLCALL SDL2COMPAT_X11EventHook(void *userdata, XEvent *xevent)
     SDL_PushEvent(&event);
     return true;
 }
-#endif /* SDL_PLATFORM_UNIX */
+#endif /* SDL2COMPAT_HAVE_X11 */
 
 /* SDL3 split this into getter/setter functions. */
 SDL_DECLSPEC Uint8 SDLCALL
@@ -10139,7 +10146,7 @@ SDL_EventState(Uint32 type, int state)
 #ifdef SDL_PLATFORM_WINDOWS
             SDL3_SetWindowsMessageHook(SDL3to2_WindowsMessageHook, NULL);
 #endif
-#if defined(SDL_PLATFORM_UNIX) && !defined(SDL_PLATFORM_ANDROID)
+#ifdef SDL2COMPAT_HAVE_X11
             SDL3_SetX11EventHook(SDL2COMPAT_X11EventHook, NULL);
 #endif
         }
@@ -10151,7 +10158,7 @@ SDL_EventState(Uint32 type, int state)
                 SDL_SetWindowsMessageHook(NULL, NULL);
             }
 #endif
-#if defined(SDL_PLATFORM_UNIX) && !defined(SDL_PLATFORM_ANDROID)
+#ifdef SDL2COMPAT_HAVE_X11
             SDL3_SetX11EventHook(NULL, NULL);
 #endif
         }


### PR DESCRIPTION
Followup for #454.

* Centralize detection of platforms that probably support X11
* Don't use quirks to force X11 things on non-X11 platforms