### PR TITLE
Improve display mode handling for dummy video driver

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -8209,6 +8209,14 @@ DisplayMode_3to2(const SDL_DisplayMode *in, SDL2_DisplayMode *out) {
         out->h = in->h;
         out->refresh_rate = (int) SDL3_lroundf(in->refresh_rate);
         out->driverdata = in->internal;
+
+        /* Make sure the returned refresh rate and format are something valid */
+        if (!out->refresh_rate) {
+            out->refresh_rate = 60;
+        }
+        if (!out->format) {
+            out->format = SDL_PIXELFORMAT_XRGB8888;
+        }
     }
 }
 
@@ -8495,11 +8503,6 @@ SDL_GetWindowDisplayMode(SDL_Window *window, SDL2_DisplayMode *mode)
         if (SDL_GetDesktopDisplayMode(display, mode) < 0) {
             return -1;
         }
-
-        /* When returning the desktop mode, make sure the refresh is some nonzero value. */
-        if (mode->refresh_rate == 0) {
-            mode->refresh_rate = 60;
-        }
     } else {
         if (!SDL_GetClosestDisplayMode(display, mode, mode)) {
             SDL_zerop(mode);
@@ -8533,14 +8536,6 @@ SDL_GetClosestDisplayMode(int displayIndex, const SDL2_DisplayMode *mode, SDL2_D
     }
 
     DisplayMode_3to2(ret3, closest);
-
-    /* Make sure the returned refresh rate and format are something valid */
-    if (!closest->refresh_rate) {
-        closest->refresh_rate = mode->refresh_rate ? mode->refresh_rate : 60;
-    }
-    if (!closest->format) {
-        closest->format = SDL_PIXELFORMAT_XRGB8888;
-    }
     return closest;
 }
 

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -8454,6 +8454,14 @@ static int ApplyFullscreenMode(SDL_Window *window)
         mode.h = property->h;
         mode.refresh_rate = (float)property->refresh_rate;
     } else {
+        int count = 0;
+        SDL3_free(SDL3_GetFullscreenDisplayModes(displayID, &count));
+
+        /* If the video driver has no fullscreen modes, transition to fullscreen desktop mode */
+        if (count == 0) {
+            return 0;
+        }
+
         SDL3_GetWindowSize(window, &mode.w, &mode.h);
     }
 
@@ -8463,6 +8471,15 @@ static int ApplyFullscreenMode(SDL_Window *window)
     if (mode.displayID && SDL3_SetWindowFullscreenMode(window, &mode)) {
         return 0;
     }
+    else if (property) {
+        const SDL_DisplayMode *desktop = SDL3_GetDesktopDisplayMode(displayID);
+
+        /* It's possible that this was an attempted transition to the desktop display mode on a driver without modesetting support */
+        if (desktop && desktop->w == property->w && desktop->h == property->h) {
+            return 0;
+        }
+    }
+
     return -1;
 }
 


### PR DESCRIPTION
The dummy video driver in SDL3 reports a refresh rate of 0, which exposed some inconsistencies amongst the various display mode APIs regarding when we default the refresh rate to 60 if it's unknown. The pysdl2 test suite caught the inconsistencies which resulted in a test failure. I moved the logic into `DisplayMode_3to2()` to ensure it applies everywhere.

The dummy video driver in SDL3 also reports no fullscreen display modes. We supported this fine on the getter side (returning the desktop mode via `SDL_GetDisplayModeList()` if no fullscreen modes existed), but didn't handle it on the setter side (`SDL_SetWindowFullscreen()` would fail the fullscreen transition if the app tried to actually use the desktop mode we returned).

Fixes #458
Fixes #459


