### PR TITLE
mouse: Reintroduce fractional mouse wheel handling with fixes

### DIFF
--- a/src/sdl2_compat.h
+++ b/src/sdl2_compat.h
@@ -1129,10 +1129,17 @@ SDL_COMPILE_TIME_ASSERT(SDL2_Event, sizeof(SDL2_Event) == sizeof(((SDL2_Event *)
 typedef SDL_EventAction SDL_eventaction;
 typedef int (SDLCALL *SDL2_EventFilter) (void *userdata, SDL2_Event *event);
 
+typedef struct EventConversionState
+{
+    float residual_scroll_x;
+    float residual_scroll_y;
+} EventConversionState;
+
 typedef struct EventFilterWrapperData
 {
     SDL2_EventFilter filter2;
     void *userdata;
+    EventConversionState *eventstate;
     struct EventFilterWrapperData *next;
 } EventFilterWrapperData;
 


### PR DESCRIPTION
The approach of having SDL3 perform integer accumulation for wheel events doesn't work for apps that use both fractional and integer scrolling. This PR brings scroll wheel accumulation back into sdl2-compat.

The previous version of integer accumulation in #378 was actually broken because it did not account for the fact that a single SDL3 event can be converted using `Event3to2()` multiple times. If that happened (ex: due to an event filter/watcher installed by the app), accumulation of residual values would happen faster than expected. This PR solves that by introducing a context struct that is passed to `Event3to2()` and reset as necessary to ensure each SDL3 event conversion results in the same SDL2 event values in each context where event conversion occurs.

While this approach does solve the problem, I don't particularly like all the context passing and reverting all over. I'm hoping someone has a better idea to acheive idempotence for `Event3to2()`. I've left this as draft for now until we decide if this approach is actually what we want to land.

Fixes #461 