### PR TITLE
Make X11 dependency required on UNIX platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,15 +223,16 @@ set(SDL2COMPAT_SRCS
   src/dynapi/SDL_dynapi.c
 )
 
+if(UNIX AND NOT ANDROID)
+  find_package(X11 REQUIRED)
+  include_directories(${X11_INCLUDE_DIR})
+endif()
+
 if(APPLE)
   list(APPEND SDL2COMPAT_SRCS
     "src/sdl2_compat_objc.m"
   )
 
-  find_package(X11)
-  if(X11_FOUND)
-    include_directories("${X11_INCLUDE_DIR}")
-  endif()
   if(POLICY CMP0068)
     cmake_policy(SET CMP0068 NEW)  # on macOS, don't let RPATH affect install_name.
   endif()


### PR DESCRIPTION
The X11 headers are included in `sdl2_compat.h` so building without them installed in the standard location fails with:

```
> In file included from /build/source/src/dynapi/SDL_dynapi.c:23:
> /build/source/src/dynapi/../sdl2_compat.h:1289:10: fatal error: X11/Xlib.h: No such file or directory
>  1289 | #include <X11/Xlib.h>
>       |          ^~~~~~~~~~~~
> compilation terminated.
```