### PR TITLE
Update palette in Surface2to3

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -3924,6 +3924,7 @@ static SDL_Surface *Surface2to3(SDL2_Surface *surface)
         surface3->flags |= (surface->flags & SHARED_SURFACE_FLAGS);
         surface3->pixels = surface->pixels;
         surface3->pitch = surface->pitch;
+        SDL3_SetSurfacePalette(surface3, surface->format->palette);
     }
     return surface3;
 }


### PR DESCRIPTION
As with some other surface properties, it's possible that an application will modify a surface's palette behind SDL2's back.  In particular, this is often used as a shortcut to emulate DirectDraw's blitting behaviour (which ignores the palette).

Synchronise the palette in Surface2to3 alongside other properties which are modified in this manner. _I think_ it should be safe to use SDL3_SetSurfacePalette() here, as if the surface's palette is unchanged, the refcount should also end up unchanged.