### PR TITLE
Check and initialize the video subsystem from within sdl2-compat when…

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -8992,6 +8992,13 @@ SDL_CreateWindow(const char *title, int x, int y, int w, int h, Uint32 flags)
     bool exclusive_fullscreen = false;
     bool manually_show = false;
 
+    /* This needs to be called from within sdl2-compat to initialize the hints and globals. */
+    if (!SDL_WasInit(SDL_INIT_VIDEO)) {
+        if (SDL_Init(SDL_INIT_VIDEO)) {
+            return NULL;
+        }
+    }
+
     CheckEventFilter();
 
     if ((flags & SDL2_WINDOW_FULLSCREEN_DESKTOP) == SDL2_WINDOW_FULLSCREEN_DESKTOP) {


### PR DESCRIPTION
… creating a window

SDL3 will implicitly initialize the video and event systems when creating a window, but that leaves the sdl2-compat globals uninitialized. Check and initialize the video subsystem from within sdl2-compat, if necessary, so that the sdl2-compat globals and hints are initialized along with the video system.

Fixes the sample code in https://gitlab.freedesktop.org/xorg/xserver/-/issues/1803#note_2960648