### PR TITLE
Don't pass SDL3 window events to SDL2 applications

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -2884,6 +2884,9 @@ EventFilter3to2(void *userdata, SDL_Event *event3)
 
                 SDL_PushEvent(&event2);
             }
+
+            /* Don't post the SDL3 version of this event */
+            post_event = false;
             break;
 
         default: break;


### PR DESCRIPTION
Fixes https://github.com/libsdl-org/sdl2-compat/issues/508