### PR TITLE
dynapi: Under SDL2COMPAT_DEBUG_LOGGING, log whether we were replaced

### DIFF
--- a/src/dynapi/SDL_dynapi.h
+++ b/src/dynapi/SDL_dynapi.h
@@ -76,4 +76,9 @@
 #define SDL_DYNAMIC_API 1
 #endif
 
+#if SDL_DYNAMIC_API
+typedef void (*SDLDynamicAPILogAtStartupFunc) (const char *);
+void SDL_DynamicAPISetLogAtStartup(SDLDynamicAPILogAtStartupFunc func);
+#endif
+
 #endif

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -1001,6 +1001,10 @@ LoadSDL3(void)
         if (WantDebugLogging) {
             // force on the SDL3 debug logging, too, so we get info on backend choices, etc.
             SDL2Compat_SetEnvAtStartup("SDL_DEBUG_LOGGING", "1");
+            // if SDL_DYNAMIC_API replaces us with some other SDL2, say so
+#if SDL_DYNAMIC_API
+            SDL_DynamicAPISetLogAtStartup(SDL2Compat_LogAtStartup);
+#endif
         }
 
         okay = LoadSDL3Library();


### PR DESCRIPTION
Otherwise our output can be misleading: we say that sdl2-compat is loaded and using SDL3 (because that happens at library constructor time, before any SDL2 API functions are called), but then SDL_DYNAMIC_API kicks in the first time we call into the SDL2 API, and potentially replaces us with classic SDL2 without leaving a trace in our output.

Resolves: https://github.com/libsdl-org/sdl2-compat/issues/515

---

This is one possible implementation of #515. I've tried to write it in a style that could be copied into SDL3, or even into classic SDL2, if wanted.

Example output:

```
sdl2-compat 2.32.57, built on Sep 10 2025 at 12:31:43, talking to SDL3 3.3.0
sdl2-compat: This app appears to be named: ioquake3
SDL_DYNAMIC_API: Library replaced by SDL 2.32.10 (SDL-release-2.32.10-0-g5d2495703 (Debian 2.32.10+dfsg-3))
```

or

```
sdl2-compat 2.32.57, built on Sep 10 2025 at 12:31:43, talking to SDL3 3.3.0
sdl2-compat: This app appears to be named: ioquake3
SDL_DYNAMIC_API: Not overridden
```