### PR TITLE
Zero-sized memory buffers are now valid in SDL3, but were not in SDL2

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -3519,7 +3519,7 @@ SDL_RWFromFile(const char *file, const char *mode)
 SDL_DECLSPEC SDL2_RWops *SDLCALL
 SDL_RWFromMem(void *mem, int size)
 {
-    if (size < 0) { /* SDL3 already checks size == 0 */
+    if (size <= 0) {
         SDL3_InvalidParamError("size");
         return NULL;
     }
@@ -3529,7 +3529,7 @@ SDL_RWFromMem(void *mem, int size)
 SDL_DECLSPEC SDL2_RWops *SDLCALL
 SDL_RWFromConstMem(const void *mem, int size)
 {
-    if (size < 0) { /* SDL3 already checks size == 0 */
+    if (size <= 0) {
         SDL3_InvalidParamError("size");
         return NULL;
     }


### PR DESCRIPTION
Introduced by https://github.com/libsdl-org/SDL/commit/2c8c2d72b501a945e35097f6056a7e4d54065e3f