### PR TITLE
Treat DEBUG_INVOCATION=1 as equivalent to SDL2COMPAT_DEBUG_LOGGING=1

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -361,6 +361,8 @@ static const char *SDL2Compat_GetEnvAtStartup(const char *name)
 static bool SDL2Compat_CheckDebugLogging(void)
 {
     const char *value = SDL2Compat_GetEnvAtStartup("SDL2COMPAT_DEBUG_LOGGING");
+    if (value == NULL)
+        value = SDL2Compat_GetEnvAtStartup("DEBUG_INVOCATION");
     return (value != NULL) && SDL2Compat_strequal(value, "1");
 }
 


### PR DESCRIPTION
In the same spirit as https://github.com/libsdl-org/SDL/issues/12275, if we enable a reasonable level of debug output whenever this variable is set, it becomes a convenient way for users to request a more verbose (but not overwhelming) amount of output. SDL 3 and GLib already do this.

Explicitly setting SDL2COMPAT_DEBUG_LOGGING=0 can override this, if it becomes necessary for whatever reason.