### PR TITLE
Preserve window creation errors set by SDL 3

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -9213,14 +9213,16 @@ SDL_CreateWindow(const char *title, int x, int y, int w, int h, Uint32 flags)
         }
     }
 
-    if (exclusive_fullscreen) {
-        ApplyFullscreenMode(window);
-        SDL3_SetWindowFullscreen(window, true);
+    if (window) {
+        if (exclusive_fullscreen) {
+            ApplyFullscreenMode(window);
+            SDL3_SetWindowFullscreen(window, true);
+        }
+        if (manually_show) {
+            SDL3_ShowWindow(window);
+        }
+        FinishWindowCreation(window);
     }
-    if (manually_show) {
-        SDL3_ShowWindow(window);
-    }
-    FinishWindowCreation(window);
 
     return window;
 }
@@ -9285,7 +9287,9 @@ SDL_CreateWindowFrom(const void *data)
     window = SDL3_CreateWindowWithProperties(props);
     SDL3_DestroyProperties(props);
 
-    FinishWindowCreation(window);
+    if (window) {
+        FinishWindowCreation(window);
+    }
 
     return window;
 }


### PR DESCRIPTION
I was trying to debug a window creation error in my application but `SDL_GetError()` was returning the unhelpful error "Invalid window" because sdl2_comapt is trying to do things to an invalid window.

I added an early check to skip these functions if SDL3's window creation returns NULL. This way we don't stomp on the error message.