### PR TITLE
Revert "Cache the SDL_PixelFormatDetails in SDL2_PixelFormat::next"

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -4232,6 +4232,7 @@ SDL_DECLSPEC SDL2_Surface * SDLCALL
 SDL_ConvertSurface(SDL2_Surface *surface, const SDL2_PixelFormat *format, Uint32 flags)
 {
     SDL_Palette *palette = NULL;
+    SDL_PixelFormat pixel_format;
     SDL2_Surface *result;
 
     (void) flags; /* SDL3 removed the (unused) `flags` argument */
@@ -4241,6 +4242,12 @@ SDL_ConvertSurface(SDL2_Surface *surface, const SDL2_PixelFormat *format, Uint32
         return NULL;
     }
     if (!format) {
+        SDL3_InvalidParamError("format");
+        return NULL;
+    }
+
+    pixel_format = SDL3_GetPixelFormatForMasks(format->BitsPerPixel, format->Rmask, format->Gmask, format->Bmask, format->Amask);
+    if (pixel_format == SDL_PIXELFORMAT_UNKNOWN) {
         SDL3_InvalidParamError("format");
         return NULL;
     }
@@ -4257,7 +4264,7 @@ SDL_ConvertSurface(SDL2_Surface *surface, const SDL2_PixelFormat *format, Uint32
         SDL3_SetPaletteColors(palette, format->palette->colors, 0, ncolors);
     }
 
-    result = Surface3to2(SDL3_ConvertSurfaceAndColorspace(Surface2to3(surface), (SDL_PixelFormat)format->format, palette, SDL_COLORSPACE_SRGB, 0));
+    result = Surface3to2(SDL3_ConvertSurfaceAndColorspace(Surface2to3(surface), pixel_format, palette, SDL_COLORSPACE_SRGB, 0));
 
     if (palette) {
         SDL3_DestroyPalette(palette);


### PR DESCRIPTION
This reverts commit 7f7b1e6b6f7054cba5eb76eca8dca5222e14029f.

Specifically, it reverts the handling of the pixel format passed to SDL3_ConvertSurfaceAndColorspace inside of SDL_ConvertSurface so that the pixel format is derived by calling SDL3_GetPixelFormatForMasks instead of using the value from format->format.

Note, the other hunks from 7f7b1e6b6 were reverted in e47c7c7fb.

Resolves: https://github.com/libsdl-org/sdl2-compat/issues/542