### PR TITLE
Fix uninitialized variable warning when compiling tests with clang compiler

### DIFF
--- a/test/testautomation_rect.c
+++ b/test/testautomation_rect.c
@@ -733,8 +733,8 @@ int rect_testIntersectRectEmpty(void *arg)
  */
 int rect_testIntersectRectParam(void *arg)
 {
-    SDL_Rect rectA;
-    SDL_Rect rectB = { 0 };
+    const SDL_Rect rectA = { 0, 0, 32, 32 };
+    const SDL_Rect rectB = { 0, 0, 32, 32 };
     SDL_Rect result;
     SDL_bool intersection;
 
@@ -988,8 +988,8 @@ int rect_testHasIntersectionEmpty(void *arg)
  */
 int rect_testHasIntersectionParam(void *arg)
 {
-    SDL_Rect rectA;
-    SDL_Rect rectB = { 0 };
+    const SDL_Rect rectA = { 0, 0, 32, 32 };
+    const SDL_Rect rectB = { 0, 0, 32, 32 };
     SDL_bool intersection;
 
     /* invalid parameter combinations */
@@ -1524,7 +1524,8 @@ int rect_testUnionRectInside(void *arg)
  */
 int rect_testUnionRectParam(void *arg)
 {
-    SDL_Rect rectA, rectB = { 0 };
+    const SDL_Rect rectA = { 0, 0, 32, 32 };
+    const SDL_Rect rectB = { 0, 0, 32, 32 };
     SDL_Rect result;
 
     /* invalid parameter combinations */


### PR DESCRIPTION
Compiling the tests with `Clang` shows these warnings:
```
[ 92%] Building C object test/CMakeFiles/testautomation.dir/testautomation_rect.c.o
sdl2-compat/test/testautomation_rect.c:744:39: warning: variable 'rectA' is uninitialized when passed as a const
      pointer argument here [-Wuninitialized-const-pointer]
  744 |     intersection = SDL_IntersectRect(&rectA, (SDL_Rect *)NULL, &result);
      |                                       ^~~~~
sdl2-compat/test/testautomation_rect.c:998:41: warning: variable 'rectA' is uninitialized when passed as a const
      pointer argument here [-Wuninitialized-const-pointer]
  998 |     intersection = SDL_HasIntersection(&rectA, (SDL_Rect *)NULL);
      |                                         ^~~~~
sdl2-compat/test/testautomation_rect.c:1533:20: warning: variable 'rectA' is uninitialized when passed as a const
      pointer argument here [-Wuninitialized-const-pointer]
 1533 |     SDL_UnionRect(&rectA, (SDL_Rect *)NULL, &result);
      |                    ^~~~~
```

This commit initializes the rect variables (and makes them `const`).
It also gives them some size, so the tests only pass if a parameter is `NULL` and not accidentally on an empty rect.

Btw:
What is the reasoning behind the function returning `false` when the `result` parameter is `NULL`?
I expected it to return `true` regardless if there is a parameter to write the resulting rect to, similar to `SDL_HasRectIntersection()`.