### PR TITLE
init: Default to X11 video if compiled with -DSTEAM_RUNTIME=2

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -6941,6 +6941,15 @@ static SDL_InitFlags PreInitSubsystem(SDL_InitFlags flags)
         const char *old_hint;
         const char *hint;
 
+#if defined(SDL2COMPAT_HAVE_X11) && defined(STEAM_RUNTIME) && STEAM_RUNTIME == 2
+        /* "Classic" SDL 2 games historically defaulted to X11,
+         * and surprisingly many games assume X11 and will crash when
+         * using native Wayland. The Steam Linux Runtime 2 container
+         * is primarily for legacy games, so accommodate their assumptions
+         * by preserving historical behaviour. */
+        SDL3_SetHint(SDL_HINT_VIDEO_DRIVER, "x11");
+#endif
+
         /* Update IME UI hint */
 #if defined(SDL_PLATFORM_WIN32)
         old_hint = SDL3_GetHint("SDL_IME_SHOW_UI");


### PR DESCRIPTION
Many older SDL 2 games and even some new ones assume that Linux builds will always use X11: for example, we already have quirks to make Darkest Dungeon, Heavy Gear 2, various Infinity Engine titles, Unreal Editor, World of Goo 2 and X4 Foundations work despite them all making this assumption.

The Steam Runtime version 2 container is mainly used for legacy games that target the even older Steam Runtime version 1 environment, so it seems wise to avoid breaking their assumptions and instead preserve the behaviour of "classic" SDL 2, where Linux games can be assumed to be X11 games unless specifically forced to use Wayland.

For the relatively legacy-free Steam Runtime 3 and 4, we'll still try to use Wayland if available, falling back to X11 if native Wayland is not available.

---

I'm not sure this actually makes much sense to apply upstream - we can easily apply Steam-Runtime-specific patches via `debian/patches/`, and we sometimes need to do this anyway for other reasons, especially in the older branches like Steam Runtime 2. But I wanted to give SDL upstream a chance to look at this.

This doesn't do anything on its own, and needs to be combined with `export CFLAGS += -DSTEAM_RUNTIME=2` in `debian/rules` in the Steam Runtime 2 branch of the sdl2-compat Debian packaging.