### PR TITLE
README: Describe how to make X11-only games not need user workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,21 @@ program is expecting:
 ```
 SDL_VIDEODRIVER=x11
 ```
+
+Please report this to the game developer as a bug.
+Game developers who know that their game engine requires X11 on Linux can
+arrange for this to happen by including code similar to this at the
+beginning of `main()`:
+```
+#ifdef SDL_VIDEO_DRIVER_X11
+SDL_SetHintWithPriority(SDL_HINT_VIDEODRIVER, "x11", SDL_HINT_OVERRIDE);
+#endif
+```
+
+This is backward-compatible with "classic" SDL 2 version 2.0.12 or later.
+If older versions need to be supported,
+set the `SDL_VIDEODRIVER` environment variable instead.
+
+For unmaintained games where applying this code change is not feasible,
+either a wrapper script can set the `SDL_VIDEODRIVER` environment variable,
+or the game can be added to the `quirks` array in sdl2-compat.


### PR DESCRIPTION
Based on documentation that I wrote in Debian for the future transition from classic SDL2 to sdl2-compat.

Adjustments welcome, both technical and wording. The message I'm aiming to get across is:

* this is really the game making an assumption that was never guaranteed to be true, and ideally game developers would fix it by either making their game work on native Wayland, or making it declare that it needs X11 (a SDL equivalent of https://github.com/vim/vim/commit/f80663f17b2)
* or for unmaintained games, the sdl2-compat team can use the `quirks` array to work around it
* and local workarounds by setting `SDL_VIDEODRIVER` should be a last resort

which I think matches the SDL upstream position on this?

Valve's Steam Runtime will probably want to be able to point to something like this, too. In Steam Linux Runtime 1.0 (and 2.0, but that one isn't directly available to game developers) the plan is to go back to X11 being the default (#557), and in SLR 3.0 and up, the plan is to default to native Wayland if available.

cc @slouken 