### PR TITLE
Disable GTK during initialization

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -1373,6 +1373,12 @@ SDL2Compat_InitOnStartupInternal(void)
     SDL3_SetHint("SDL_VIDEO_SYNC_WINDOW_OPERATIONS", "1");
     SDL3_SetHint("SDL_VIDEO_X11_EXTERNAL_WINDOW_INPUT", "0");
 
+    // Don't use GTK for tray icons. This conflicts with the historical
+    // practice of making game executables be setgid 'games' in order to
+    // write out a shared high score table, and is only used to implement
+    // a feature that SDL 2 didn't have, so it's unnecessary here.
+    SDL3_SetHint("SDL_ENABLE_GTK", "0");
+
     /* Emulate integer mouse coordinates */
     SDL3_SetHint("SDL_MOUSE_INTEGER_MODE", "1");
 


### PR DESCRIPTION
If SDL 3 loads and initializes GTK, GTK will exit the process if it detects a setgid executable. This is incompatible with the historical practice of making game executables setgid in order to write out a shared high-score table on multi-user systems (which is security theatre at best, because typical game runtime libraries are not hardened against an untrusted caller, but making it regress would be a user-observable regression in sdl2-compat).

Helps: https://github.com/libsdl-org/sdl2-compat/issues/564

---

Successfully tested with [Help Hannah's Horse](https://tracker.debian.org/pkg/hannah), but additionally requires https://github.com/libsdl-org/SDL/pull/14712 to be fully effective on Wayland desktops.