### PR TITLE
Add SDL2COMPAT_DISABLE_X11 guards

### DIFF
--- a/include/SDL2/SDL_syswm.h
+++ b/include/SDL2/SDL_syswm.h
@@ -59,7 +59,7 @@ struct SDL_SysWMinfo;
 #endif
 
 /* This is the structure for custom window manager events */
-#if defined(SDL_VIDEO_DRIVER_X11)
+#if defined(SDL_VIDEO_DRIVER_X11) && !defined(SDL2COMPAT_DISABLE_X11)
 #if defined(__APPLE__) && defined(__MACH__)
 /* conflicts with Quickdraw.h */
 #define Cursor X11Cursor
@@ -168,7 +168,7 @@ struct SDL_SysWMmsg
             LPARAM lParam;              /**< LONG message parameter */
         } win;
 #endif
-#if defined(SDL_VIDEO_DRIVER_X11)
+#if defined(SDL_VIDEO_DRIVER_X11) && !defined(SDL2COMPAT_DISABLE_X11)
         struct {
             XEvent event;
         } x11;
@@ -243,7 +243,7 @@ struct SDL_SysWMinfo
             IInspectable * window;      /**< The WinRT CoreWindow */
         } winrt;
 #endif
-#if defined(SDL_VIDEO_DRIVER_X11)
+#if defined(SDL_VIDEO_DRIVER_X11) && !defined(SDL2COMPAT_DISABLE_X11)
         struct
         {
             Display *display;           /**< The X11 display */


### PR DESCRIPTION
This is so programs that include SDL_syswm.h can build when X11 is disabled.

See: https://github.com/libsdl-org/sdl2-compat/issues/533#issuecomment-3694436279