### PR TITLE
surface: sync SDL3 surface on free

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -4417,8 +4417,7 @@ SDL_FreeSurface(SDL2_Surface *surface)
     }
 
     if (surface->map) {
-        SDL_Surface *surface3 = (SDL_Surface *)surface->map;
-        SDL3_DestroySurface(surface3);
+        SDL3_DestroySurface(Surface2to3(surface));
         surface->map = NULL;
     }
 


### PR DESCRIPTION
If the app doesn't call any surface functions prior to calling SDL_FreeSurface(), changes made to the SDL2 surface will not be propagated to the SDL3 surface. This may cause the pixel data to be leaked or freed incorrectly.

Pixel data for surfaces allocated by SDL_ttf was being leaked as a result of this bug due to the [surface memory tricks](https://github.com/libsdl-org/SDL_ttf/blob/4a1151cff04e360df45b55a653f7a7def492ad9b/SDL_ttf.c#L1482-L1484) it uses.

Downstream bug report: https://github.com/moonlight-stream/moonlight-qt/issues/1793