### PR TITLE
Ignore more build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 cmake-build
+build/
+build-*/
+!build-scripts/


### PR DESCRIPTION
Same as in the SDL repo

https://github.com/libsdl-org/SDL/blob/72ed7d0f8715f8dbfb0c8dcd4103cd92c9573c72/.gitignore#L1-L3

I usually call my build directory just "build" or "build-my-cmake-flags" and especially while building tests this causes a bunch of work tree dirtying. The best approach is to allow any kind of build directory name by ignoring the files it contains instead of its name. But that would be a bigger diff so I decided to went the easy route which is also supported by the main SDL repo.