### PR TITLE
Force software rendering in Domino-Chain

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -503,6 +503,11 @@ static QuirkEntryType quirks[] = {
     { "tauon/__main__.py", SDL_HINT_VIDEO_WAYLAND_SCALE_TO_DISPLAY, "0" },
     { "tauon/__main__.py", SDL_HINT_VIDEO_WAYLAND_ALLOW_LIBDECOR, "0" },
 
+    /* Domino-Chain relies on presented backbuffers having their contents preserved,
+     * which is undefined behavior on all but the software renderer.
+     */
+    { "domino-chain", SDL_HINT_RENDER_DRIVER, "software" },
+
 #ifdef SDL2COMPAT_HAVE_X11
     /* Stylus Labs Write does its own X11 input handling */
     { "Write", "SDL_VIDEO_X11_XINPUT2", "0" },
@@ -9845,13 +9850,14 @@ SDL_SetWindowKeyboardGrab(SDL_Window *window, SDL2_bool grabbed)
 SDL_DECLSPEC void SDLCALL
 SDL_SetWindowMouseGrab(SDL_Window *window, SDL2_bool grabbed)
 {
-    SDL_Window *prev_grab_wind = SDL3_GetGrabbedWindow();
+    SDL_Window *prev_grab_wind;
 
     if (!window) {
         SDL3_SetError("Invalid window");
         return;
     }
 
+    prev_grab_wind = SDL3_GetGrabbedWindow();
     SDL3_SetWindowMouseGrab(window, grabbed);
 
     if (prev_grab_wind && prev_grab_wind != window && grabbed) {


### PR DESCRIPTION
The game relies on backbuffers having their contents preserved after presentation, which is undefined behavior when using the GL or Vulkan renderers, and results in flicker on some platform/driver combinations.

Fixes #569 