### PR TITLE
Restore SDL_VIDEO_OPENGL_ES2 define for SDL2 compile-time compatibility

### DIFF
--- a/include/SDL2/SDL_config_unix.h.cmake
+++ b/include/SDL2/SDL_config_unix.h.cmake
@@ -259,6 +259,7 @@
 /* Enable OpenGL support */
 #define SDL_VIDEO_OPENGL 1
 #define SDL_VIDEO_OPENGL_ES 1
+#define SDL_VIDEO_OPENGL_ES2 1
 #define SDL_VIDEO_OPENGL_GLX 1
 #if defined(__LINUX__)
 #define SDL_VIDEO_OPENGL_EGL 1


### PR DESCRIPTION
This restores the SDL_VIDEO_OPENGL_ES2 preprocessor define in the Unix config header for compatibility. 