### PR TITLE
hint: Add SDL2_COMPAT hint for SDL3 compatibility features

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -1087,6 +1087,7 @@ LoadSDL3(void)
                     }
                     SDL2Compat_ApplyQuirks(force_x11);  /* Apply and maybe print a list of any enabled quirks. */
                     SDL2Compat_SetEnvAtStartup("SDL3_VERSION", sdl3verstr);
+                    SDL2Compat_SetEnvAtStartup("SDL2_COMPAT", "1");
                 }
             }
             #define SDL3_SYM(rc,fn,params,args,ret) SDL3_##fn = (SDL3_##fn##_t) LoadSDL3Symbol("SDL_" #fn, &okay);


### PR DESCRIPTION
This enables the compatibility behavior for rumble support being introduced in https://github.com/libsdl-org/SDL/pull/15488 to partially address https://github.com/libsdl-org/sdl2-compat/issues/590.

I opted to use `SDL2Compat_SetEnvAtStartup()` instead of `SDL3_SetHint()` to avoid the hint getting nuked if the app calls `SDL_ResetHints()`.