### PR TITLE
Use Standard C strlen(), etc., if we're using libc anyway

### DIFF
--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -272,6 +272,7 @@ SDL2COMPAT_itoa(char *dst, int val)
 /* you can use SDL3_strlen once we're past startup. */
 static size_t SDL2Compat_strlen(const char *str)
 {
+#ifdef SDL_PLATFORM_WINDOWS
     /* volatile prevents gcc from optimizing this into a call to the
      * strlen() library function, which we are intentionally avoiding on
      * Windows: see #340 */
@@ -280,11 +281,16 @@ static size_t SDL2Compat_strlen(const char *str)
         ++ptr;
     }
     return (size_t)(ptr - str);
+#else
+    /* On other platforms we rely on libc */
+    return strlen (str);
+#endif
 }
 
 /* you can use SDL3_strcmp once we're past startup. */
 static bool SDL2Compat_strequal(const char *a, const char *b)
 {
+#ifdef SDL_PLATFORM_WINDOWS
     while (true) {
         const char cha = *a;
         if (cha != *b) {
@@ -296,11 +302,15 @@ static bool SDL2Compat_strequal(const char *a, const char *b)
         b++;
     }
     return true;
+#else
+    return (strcmp (a, b) == 0);
+#endif
 }
 
 /* you can use SDL3_strrchr once we're past startup. */
 static char *SDL2Compat_strrchr(const char *string, int c)
 {
+#ifdef SDL_PLATFORM_WINDOWS
     const char *bufp = string + SDL2Compat_strlen(string);
     while (bufp >= string) {
         if (*bufp == c) {
@@ -309,6 +319,9 @@ static char *SDL2Compat_strrchr(const char *string, int c)
         --bufp;
     }
     return NULL;
+#else
+    return (char *) strrchr (string, c);
+#endif
 }
 
 /* log a string using platform-specific code for before SDL3 is fully available. */

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -898,7 +898,7 @@ SDL2Compat_ApplyQuirks(bool force_x11)
     if (WantDebugLogging) {
         const char *lead = "sdl2-compat: This app appears to be named:";
         char msg[256];
-        if ((SDL2Compat_strlen(lead) + SDL2Compat_strlen(exe_name) + 2) <= sizeof (msg)) {
+        if (SDL2Compat_strlen(exe_name) <= sizeof (msg) - (SDL2Compat_strlen(lead) + 2)) {
             char *p = msg;
             p = SDL2COMPAT_stpcpy(p, lead);
             p = SDL2COMPAT_stpcpy(p, " ");

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -272,6 +272,9 @@ SDL2COMPAT_itoa(char *dst, int val)
 /* you can use SDL3_strlen once we're past startup. */
 static int SDL2Compat_strlen(const char *str)
 {
+    /* volatile prevents gcc from optimizing this into a call to the
+     * strlen() library function, which we are intentionally avoiding on
+     * Windows: see #340 */
     volatile const char *ptr = str;
     while (*ptr) {
         ++ptr;

--- a/src/sdl2_compat.c
+++ b/src/sdl2_compat.c
@@ -270,7 +270,7 @@ SDL2COMPAT_itoa(char *dst, int val)
 }
 
 /* you can use SDL3_strlen once we're past startup. */
-static int SDL2Compat_strlen(const char *str)
+static size_t SDL2Compat_strlen(const char *str)
 {
     /* volatile prevents gcc from optimizing this into a call to the
      * strlen() library function, which we are intentionally avoiding on
@@ -279,7 +279,7 @@ static int SDL2Compat_strlen(const char *str)
     while (*ptr) {
         ++ptr;
     }
-    return (int)(ptr - str);
+    return (size_t)(ptr - str);
 }
 
 /* you can use SDL3_strcmp once we're past startup. */
@@ -898,7 +898,7 @@ SDL2Compat_ApplyQuirks(bool force_x11)
     if (WantDebugLogging) {
         const char *lead = "sdl2-compat: This app appears to be named:";
         char msg[256];
-        if ((SDL2Compat_strlen(lead) + SDL2Compat_strlen(exe_name) + 2) <= (int) (sizeof (msg))) {
+        if ((SDL2Compat_strlen(lead) + SDL2Compat_strlen(exe_name) + 2) <= sizeof (msg)) {
             char *p = msg;
             p = SDL2COMPAT_stpcpy(p, lead);
             p = SDL2COMPAT_stpcpy(p, " ");


### PR DESCRIPTION
As I suggested on #340 a while ago.

* Restore comment explaining why volatile is used in SDL2Compat_strlen()

* Make SDL2Compat_strlen return size_t
    
    This gives it the same signature as Standard C strlen(), and avoids the
    possibility of signed integer overflow.

* SDL2Compat_ApplyQuirks: Avoid overflow for extremely long exe_name
    
    The length of `exe_name` is (at least in theory) unbounded, so adding
    anything to it could overflow, but we know that the right-hand side
    of the `<=` evaluates to a positive constant.

* Use Standard C strlen(), etc., if we're using libc anyway
    
    On some platforms (notably Windows) we don't want to use the system C
    library, so we avoid using Standard C strlen() and use our own
    implementation. On other platforms (notably Linux) we require the system
    C library anyway, for functions like setenv(), so we might as well make
    full use of it.
    
    In particular this means that our fallback implementations only need
    to work on Windows, so it's now OK if the workarounds we use to avoid the
    compiler replacing our open-coded strlen() with a call to the library
    strlen() (see #340) are not 100% portable.