### PR TITLE
Cygwin/Mingw fix support requires patch to SDL 3.4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,13 @@ set(SDL_MINOR_VERSION ${sdl2_compat_VERSION_MINOR})
 set(SDL_MICRO_VERSION ${sdl2_compat_VERSION_PATCH})
 set(SDL_VERSION "${SDL_MAJOR_VERSION}.${SDL_MINOR_VERSION}.${SDL_MICRO_VERSION}")
 
+if(CYGWIN AND CMAKE_C_COMPILER MATCHES ".*[-]mingw32[-].*")
+  set(MINGW 1)
+  set(WINDOWS 1)
+  set(WIN32 1)
+  set(UNIX 0)
+endif()
+
 include(CheckCSourceCompiles)
 include(CheckIncludeFile)
 include(CheckCCompilerFlag)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,7 +388,12 @@ else()
   )
 endif()
 
-if(MINGW)
+if(CYGWIN AND CMAKE_C_COMPILER MATCHES ".*[-]mingw32[-].*")
+  set_property(TARGET SDL2 APPEND_STRING PROPERTY LINK_FLAGS " -nostdlib")
+  # need libgcc for emulating 64-bit operations (e.g. 64-bit division) or __chkstk_ms()
+  # need user32 and kernel32 to prevent linking errors when building
+  target_link_libraries(SDL2 PRIVATE user32 kernel32 gcc)
+elseif(MINGW)
   set_property(TARGET SDL2 APPEND_STRING PROPERTY LINK_FLAGS " -nostdlib")
   if(USE_CLANG)
     if(SDL_CPU_X86)


### PR DESCRIPTION
I have gotten SDL 3.4.x and sdl-compat repos to build with these cmake options:
```
    -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc
    -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++
    -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres
```
SDL 3.4.x patch needed
```
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 1785395fb..ed7461ec5 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,13 @@ if(POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif()
 
+if(CYGWIN AND CMAKE_C_COMPILER MATCHES ".*[-]mingw32[-].*")
+  set(MINGW 1)
+  set(WINDOWS 1)
+  set(WIN32 1)
+  set(UNIX 0)
+endif()
+
 include(CheckLibraryExists)
 include(CheckIncludeFile)
```

I have not yet tested the built binary except for doing the normal ctest tests; the sdl2-config looked okay, but it should be tested.
